### PR TITLE
 Reset lurker status when a lurker's level is played or the queue is cleared

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ const next_level_message = (level) => {
   if (level === undefined) {
     return "The queue is empty.";
   }
-  twitch.notLurkingAnymore(level.submitter); // If we pull up a level, we should reset the lurking status
+  twitch.notLurkingAnymore(level.username); // If we pull up a level, we should reset the lurking status
   if (level.code == "R0M-HAK-LVL") {
     return "Now playing a ROMhack submitted by " + level.submitter + ".";
   } else {
@@ -100,7 +100,7 @@ const weightedrandom_level_message = (level, percentSuffix = '') => {
   if (level === undefined) {
     return "The queue is empty.";
   }
-  twitch.notLurkingAnymore(level.submitter); // If we pull up a level, we should reset the lurking status
+  twitch.notLurkingAnymore(level.username); // If we pull up a level, we should reset the lurking status
   if (level.code == "R0M-HAK-LVL") {
     return (
       "Now playing a ROMhack submitted by " +
@@ -337,6 +337,8 @@ async function HandleMessage(message, sender, respond) {
       var to_remove = get_remainder(message);
       respond(quesoqueue.modRemove(to_remove));
     } else {
+      // if they're leaving, they're not lurking
+      twitch.notLurkingAnymore(sender.username);
       respond(quesoqueue.remove(sender.displayName));
     }
   } else if (
@@ -497,7 +499,7 @@ async function HandleMessage(message, sender, respond) {
     }
     var dip_level = quesoqueue.dip(username);
     if (dip_level !== undefined) {
-      twitch.notLurkingAnymore(username);
+      twitch.notLurkingAnymore(dip_level.username);
       if (dip_level.code == "R0M-HAK-LVL") {
         respond(
           "Now playing a ROMhack submitted by " + dip_level.submitter + "."

--- a/src/index.js
+++ b/src/index.js
@@ -325,6 +325,11 @@ async function HandleMessage(message, sender, respond) {
     respond("The queue is now closed!");
   } else if (message.toLowerCase().startsWith("!add")) {
     if (queue_open || sender.isBroadcaster) {
+      // If they just added their level, it's a safe bet they aren't lurking
+      if (twitch.notLurkingAnymore(sender.username)) {
+        // But to avoid confusion, we can welcome them back too
+        respond("Welcome back, " + sender.displayName + "!");
+      }
       let level_code = get_remainder(message);
       respond(
         quesoqueue.add(Level(level_code, sender.displayName, sender.username))

--- a/src/index.js
+++ b/src/index.js
@@ -352,6 +352,11 @@ async function HandleMessage(message, sender, respond) {
     message.startsWith("!swap")
   ) {
     let level_code = get_remainder(message);
+    // If they just added their level, it's a safe bet they aren't lurking
+    if (twitch.notLurkingAnymore(sender.username)) {
+      // But to avoid confusion, we can welcome them back too
+      respond("Welcome back, " + sender.displayName + "!");
+    }
     respond(quesoqueue.replace(sender.displayName, level_code));
   } else if (message == "!level" && sender.isBroadcaster) {
     let next_level;

--- a/src/index.js
+++ b/src/index.js
@@ -126,6 +126,7 @@ const weightednext_level_message = (level, percentSuffix = '') => {
   if (level === undefined) {
     return "The queue is empty.";
   }
+  twitch.notLurkingAnymore(level.username); // If we pull up a level, we should reset the lurking status
   if (level.code == "R0M-HAK-LVL") {
     return (
       "Now playing a ROMhack submitted by " +

--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,7 @@ const next_level_message = (level) => {
   if (level === undefined) {
     return "The queue is empty.";
   }
+  twitch.notLurkingAnymore(level.submitter); // If we pull up a level, we should reset the lurking status
   if (level.code == "R0M-HAK-LVL") {
     return "Now playing a ROMhack submitted by " + level.submitter + ".";
   } else {
@@ -99,6 +100,7 @@ const weightedrandom_level_message = (level, percentSuffix = '') => {
   if (level === undefined) {
     return "The queue is empty.";
   }
+  twitch.notLurkingAnymore(level.submitter); // If we pull up a level, we should reset the lurking status
   if (level.code == "R0M-HAK-LVL") {
     return (
       "Now playing a ROMhack submitted by " +
@@ -495,6 +497,7 @@ async function HandleMessage(message, sender, respond) {
     }
     var dip_level = quesoqueue.dip(username);
     if (dip_level !== undefined) {
+      twitch.notLurkingAnymore(username);
       if (dip_level.code == "R0M-HAK-LVL") {
         respond(
           "Now playing a ROMhack submitted by " + dip_level.submitter + "."
@@ -596,6 +599,7 @@ async function HandleMessage(message, sender, respond) {
     respond(`@${sender.displayName} ${response}`);
   } else if (message == "!clear" && sender.isBroadcaster) {
     quesoqueue.clear();
+    twitch.clearLurkers();
     respond("The queue has been cleared!");
   } else if (
     (message.startsWith("!customcode") || message == "!customcodes") &&

--- a/src/queue.js
+++ b/src/queue.js
@@ -206,6 +206,10 @@ const queue = {
       return "You can use !remove <username> to kick out someone else's level.";
     }
 
+    // Unlurk the user regardless of whether they're in the queue
+    // It's unlikely they'll be on BRB and not in the queue, but it's worth protecting against
+    twitch.notLurkingAnymore(usernameArgument);
+
     var match = queue.matchUsername(usernameArgument);
     if (!levels.some(match)) {
       return "No levels from " + usernameArgument + " were found in the queue.";
@@ -216,6 +220,7 @@ const queue = {
   },
 
   remove: (username) => {
+    twitch.notLurkingAnymore(username); // If a user is leaving, they're not lurking
     if (current_level != undefined && current_level.submitter == username) {
       return "Sorry, we're playing that level right now!";
     }

--- a/src/queue.js
+++ b/src/queue.js
@@ -206,21 +206,20 @@ const queue = {
       return "You can use !remove <username> to kick out someone else's level.";
     }
 
-    // Unlurk the user regardless of whether they're in the queue
-    // It's unlikely they'll be on BRB and not in the queue, but it's worth protecting against
-    twitch.notLurkingAnymore(usernameArgument);
-
-    var match = queue.matchUsername(usernameArgument);
-    if (!levels.some(match)) {
+    var level = levels.find(queue.matchUsername(usernameArgument));
+    if (!level) {
+      // If the user isn't in the queue, unlurk them anyway
+      // It's unlikely they'll be on BRB and not in queue, but it's an edge case worth covering
+      twitch.notLurkingAnymore(usernameArgument.replace("@", "").toLowerCase());
       return "No levels from " + usernameArgument + " were found in the queue.";
     }
-    levels = levels.filter(level => !match(level));
+    twitch.notLurkingAnymore(level.username);
+    levels = levels.filter(x => x.submitter != level.submitter);
     queue.save();
     return usernameArgument + "'s level has been removed from the queue.";
   },
 
   remove: (username) => {
-    twitch.notLurkingAnymore(username); // If a user is leaving, they're not lurking
     if (current_level != undefined && current_level.submitter == username) {
       return "Sorry, we're playing that level right now!";
     }

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -71,6 +71,10 @@ const twitch = {
     return false;
   },
 
+  clearLurkers: () => {
+    lurkers.clear();
+  },
+
   getWaitTime: async (chatter) => {
 
   }


### PR DESCRIPTION
Had an issue with one of my viewers who consistently showed as offline despite clearly being online; we managed to figure out that it was because he !brb'd at some point and never did !back. If you're running the bot only during streams this is fine, but when you run the bot persistently it never gets a chance to reset the lurkers.

This PR resets the list of lurkers on clear, as well as when a level is manually selected, to prevent such cases.

(original PR: ToransuShoujo/quesoqueue_plus#38. Rebased and recreating this here.)