### PR TITLE
Fix founders not being counted as subscribers

### DIFF
--- a/src/chatbot.js
+++ b/src/chatbot.js
@@ -59,7 +59,7 @@ const chatbot_helper = function(username, password, channel) {
         } else {
           chatter = build_chatter(tags.username,
             tags['display-name'],
-            tags.badges.subscriber != undefined,
+            tags.badges.subscriber != undefined || tags.badges.founder != undefined,
             tags.badges.moderator != undefined,
             tags.badges.broadcaster != undefined);
         }


### PR DESCRIPTION
Fixes a bug where founders were not counted as subscribers, because they do not have a subscriber badge (unless they don't show their founder badge).

Therefore the queue will now tread someone with a founder badge the same as if they had a subscriber badge.