### PR TITLE
Use prettySaveFiles setting for the ./settings folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Possible values are: `"next"`, `"subnext"`, `"modnext"`, `"random"`, `"weightedr
 
 `dataIdMakerThreshold` is the highest allowed data ID for maker IDs. This is used to stop maker IDs that do not exist from entering the queue, however it is very difficult to know and/or dynamically change this amount accordingly. As such, the default value is `null`, which ignores the restriction.
 
-`prettySaveFiles` if set to true the files in the `./data/` directory are going to be formatted with spaces and new lines. The default value is `false` to reduce file size.
+`prettySaveFiles` if set to true the files in the `./data/` and `./settings` directory are going to be formatted with spaces and new lines. The default value is `false` to reduce file size.
 
 `subscriberWeightMultiplier` is the number added as a wait time for subscribers. The default value is `1.0`. Setting this to `1.2` for example will give subscribers an advantage for weighted random, because they would get 6 minutes of wait time per 5 minutes of waiting. This can be set to anything greater than or equal to `1.0`.
 

--- a/src/aliases.js
+++ b/src/aliases.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const writeFileAtomic = require('write-file-atomic');
 const writeFileAtomicSync = writeFileAtomic.sync;
+const settings = require('./settings.js');
 
 const ALIASES_FILE = {directory: './settings', fileName: './settings/aliases.json'}
 
@@ -48,11 +49,11 @@ const Aliases = {
         if(!fs.existsSync(ALIASES_FILE.directory)){
             fs.mkdirSync(ALIASES_FILE.directory);
         }
-        writeFileAtomicSync(ALIASES_FILE.fileName, JSON.stringify(aliases));
+        writeFileAtomicSync(ALIASES_FILE.fileName, JSON.stringify(aliases, null, settings.prettySaveFiles ? 2 : 0));
     },
     loadAliases : (create = false) => {
         if(create){
-            const defaults = JSON.stringify(defaultAliases, null, 2);
+            const defaults = JSON.stringify(defaultAliases, null, settings.prettySaveFiles ? 2 : 0);
             if(!fs.existsSync(ALIASES_FILE.directory)){
                 fs.mkdirSync(ALIASES_FILE.directory, {recursive: true});
             }

--- a/tests/chat-logs/chat-logs.test.js
+++ b/tests/chat-logs/chat-logs.test.js
@@ -159,7 +159,7 @@ const chatLogTest = (fileName) => {
                         }
                         expect(jsonData).toEqual(JSON.parse(rest));
                     } catch (error) {
-                        error.message += errorMessage(position());
+                        error.message += errorMessage(position);
                         throw error;
                     }
                 } else if (command.startsWith('save')) {


### PR DESCRIPTION
Files in `./settings` are now formatted if the `prettySaveFiles` setting is set to `true`.
Also fix a bug in the test cases.