### PR TITLE
Add tests to OCW

### DIFF
--- a/src/extensions/ocw.js
+++ b/src/extensions/ocw.js
@@ -51,11 +51,14 @@ const extractValidCode = (levelCode, lenient = false) => {
 };
 
 const codeSuffix = (levelCode) => {
-  const makerCode = extractValidCode(levelCode).makerCode;
-  if (makerCode && settings.showMakerCode !== false) {
-    return " (OCW maker code)";
+  if (settings.showMakerCode !== false) {
+    const makerCode = extractValidCode(levelCode).makerCode;
+    if (makerCode) {
+      return " (OCW maker code)";
+    }
+    return " (OCW level code)";
   }
-  return " (OCW level code)";
+  return " (OCW)";
 };
 
 const levelType = {

--- a/src/extensions/smm2.js
+++ b/src/extensions/smm2.js
@@ -75,9 +75,11 @@ const extractValidCode = (levelCode, strict = true) => {
 };
 
 const makerSuffix = (levelCode) => {
-  const makerCode = extractValidCode(levelCode).makerCode;
-  if (makerCode && settings.showMakerCode !== false) {
-    return " (maker code)";
+  if (settings.showMakerCode !== false) {
+    const makerCode = extractValidCode(levelCode).makerCode;
+    if (makerCode) {
+      return " (maker code)";
+    }
   }
   return "";
 };

--- a/tests/chat-logs/chat/ocw.test.log
+++ b/tests/chat-logs/chat/ocw.test.log
@@ -1,0 +1,49 @@
+# "username" will decide which of the messages are from the bot
+settings {"username":"helperblock","password":"oauth:test","channel":"liquidnya","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false}
+# chatters 
+chatters {"_links":{},"chatter_count":4,"chatters":{"broadcaster":["liquidnya"],"vips":[],"moderators":["furretwalkbot","streamelements"],"staff":[],"admins":[],"global_mods":[],"viewers":["viewerlevels"]}}
+# chatty chat log
+# ~ broadcaster
+# @ moderator
+# % subscriber
+
+[02:19:13] ~%?liquidnya: !open
+[02:19:14] @^helperblock: The queue is now open!
+
+# smm2 codes can be submitted
+[02:19:42] @^FurretWalkBot: !add NB0-1MD-SLG
+[02:19:42] @^helperblock: FurretWalkBot, NB0-1MD-SLG has been added to the queue.
+
+# can not add ocw level codes because ocw is not configured yet!
+[20:29:40] ~%?liquidnya: !add N41-Q4W-HD5
+[20:29:41] @^helperblock: liquidnya, that is an invalid level code.
+[20:29:53] ~%?liquidnya: !add RHC-D08-CC8
+[20:29:54] @^helperblock: liquidnya, that is an invalid level code.
+
+# configure ocw
+settings {"username":"helperblock","password":"oauth:test","channel":"liquidnya","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"]}
+# restart to reload settings
+restart
+
+# now it is working!
+[20:32:15] ~%?liquidnya: !add N41-Q4W-HD5
+[20:32:16] @^helperblock: liquidnya, N41-Q4W-HD5 (OCW) has been added to the queue.
+[20:32:21] ~%?liquidnya: !add RHC-D08-CC8
+[20:32:21] @^helperblock: liquidnya, RHC-D08-CC8 (OCW) has been added to the queue.
+
+# also check if ocw-lenient is working
+# FIXME: this is not working yet, because not all matches are checked
+# [20:36:15] ~%?liquidnya: !add please play this level N41-Q4W-HD5 thank you!
+# [20:36:16] @^helperblock: liquidnya, N41-Q4W-HD5 (OCW) has been added to the queue.
+# [20:36:21] ~%?liquidnya: !add please play this level RHC-D08-CC8 thank you!
+# [20:36:21] @^helperblock: liquidnya, RHC-D08-CC8 (OCW) has been added to the queue.
+
+# showMakerCode
+settings {"username":"helperblock","password":"oauth:test","channel":"liquidnya","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"]}
+# restart to reload settings
+restart
+
+[20:32:15] ~%?liquidnya: !add N41-Q4W-HD5
+[20:32:16] @^helperblock: liquidnya, N41-Q4W-HD5 (OCW level code) has been added to the queue.
+[20:32:21] ~%?liquidnya: !add RHC-D08-CC8
+[20:32:21] @^helperblock: liquidnya, RHC-D08-CC8 (OCW maker code) has been added to the queue.


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you run `eslint` on the code and resolved any errors?
- [x] Have you run `npm test` and all tests are passing?
- [x] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

These changes add tests to the `ocw` extension.

There is one thing that i noticed during testing:

When a level code or maker code is added when the `showMakerCode` setting is set to false (default is true), then chat always shows codes with the ` (OCW level code)` prefix, regardless if the code is a maker code or level code.
I changed this behavior to use the ` (OCW)` prefix in case `showMakerCode` is set to false and ` (OCW level code)` and ` (OCW maker code)` is then used when `showMakerCode` is unset or set to true.

I also changed the `ssm2` implementation of display to not validate levels in case this setting is set to false since the validation result is ignored in that case.

### Benefits
Tests for #37.

### Potential drawbacks

Likely none.