### PR TITLE
Fix race condition crash for !chance command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [2.0.0-beta.2]
+
+## Bug fixes
+
+- Fix race condition that leads to crash when using the `!chance` command (#63)
+
 # [2.0.0-beta.1]
 
 ## Breaking changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fluid-queue",
-  "version": "2.0.0",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fluid-queue",
-      "version": "2.0.0",
+      "version": "2.0.0-beta.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@twurple/api": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluid-queue",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "A queue system for Super Mario Maker 2 levels",
   "homepage": "https://fluid-queue.dev/",
   "bugs": {

--- a/src/index.js
+++ b/src/index.js
@@ -784,7 +784,7 @@ async function HandleMessage(message, sender, respond) {
         respond(level_list_message(sender.displayName, current, list));
       }
       if (list_weight) {
-        const weightedList = await quesoqueue.weightedList(true, list);
+        const weightedList = quesoqueue.weightedList(list, true);
         respond(
           level_weighted_list_message(sender.displayName, current, weightedList)
         );

--- a/src/queue.js
+++ b/src/queue.js
@@ -218,7 +218,9 @@ const queue = {
 
   /** @type {(username: string, list?: onlineOfflineList) => Promise<number>} */
   weightedPosition: async (username, list = undefined) => {
-    const weightedList = await queue.weightedList(true, list);
+    if (list === undefined) {
+      list = await queue.list();
+    }
     if (current_level != undefined && current_level.username == username) {
       return 0;
     }
@@ -228,6 +230,8 @@ const queue = {
     if (twitch.checkLurk(username)) {
       return -2;
     }
+
+    const weightedList = queue.weightedList(list, true);
     const index = weightedList.entries.findIndex(
       (x) => x.level.username == username
     );
@@ -251,7 +255,7 @@ const queue = {
   },
 
   weightedchance: async (displayName, username) => {
-    const weightedList = await queue.weightedList(false);
+    const list = await queue.list();
     if (current_level != undefined && current_level.submitter == displayName) {
       return 0;
     }
@@ -261,6 +265,8 @@ const queue = {
     if (twitch.checkLurk(username)) {
       return -2;
     }
+
+    const weightedList = queue.weightedList(list, false);
 
     if (weightedList.entries.length == 0) {
       return -1;
@@ -414,9 +420,12 @@ const queue = {
   },
 
   weightedrandom: async (list = undefined) => {
-    const weightedList = await queue.weightedList(false, list, {
-      forceRefresh: true,
-    });
+    if (list === undefined) {
+      list = queue.list({
+        forceRefresh: true,
+      });
+    }
+    const weightedList = queue.weightedList(list, false);
     const removedLevels = current_level === undefined ? [] : [current_level];
 
     if (weightedList.entries.length == 0) {
@@ -474,11 +483,8 @@ const queue = {
     return { ...current_level, selectionChance };
   },
 
-  /** @type {(sorted?: boolean, list?: onlineOfflineList) => Promise<weightedList>} */
-  weightedList: async (sorted = undefined, list = undefined, options = {}) => {
-    if (list === undefined) {
-      list = await queue.list(options);
-    }
+  /** @type {(list: onlineOfflineList, sorted?: boolean) => weightedList} */
+  weightedList: (list, sorted) => {
     const online_users = list.online;
     if (online_users.length == 0 || Object.keys(waiting).length == 0) {
       return {
@@ -541,9 +547,12 @@ const queue = {
   },
 
   weightednext: async (list = undefined) => {
-    const weightedList = await queue.weightedList(true, list, {
-      forceRefresh: true,
-    });
+    if (list === undefined) {
+      list = await queue.list({
+        forceRefresh: true,
+      });
+    }
+    const weightedList = queue.weightedList(list, true);
     const removedLevels = current_level === undefined ? [] : [current_level];
 
     if (weightedList.entries.length == 0) {

--- a/src/queue.js
+++ b/src/queue.js
@@ -184,15 +184,14 @@ const queue = {
 
   /** @type {(username: string, list?: onlineOfflineList) => Promise<number>} */
   position: async (username, list = undefined) => {
+    if (list === undefined) {
+      list = await queue.list();
+    }
     if (current_level != undefined && current_level.username == username) {
       return 0;
     }
     if (levels.length == 0) {
       return -1;
-    }
-
-    if (list === undefined) {
-      list = await queue.list();
     }
     var both = list.online.concat(list.offline);
     var index = both.findIndex((x) => x.username == username);
@@ -219,6 +218,7 @@ const queue = {
 
   /** @type {(username: string, list?: onlineOfflineList) => Promise<number>} */
   weightedPosition: async (username, list = undefined) => {
+    const weightedList = await queue.weightedList(true, list);
     if (current_level != undefined && current_level.username == username) {
       return 0;
     }
@@ -228,7 +228,6 @@ const queue = {
     if (twitch.checkLurk(username)) {
       return -2;
     }
-    const weightedList = await queue.weightedList(true, list);
     const index = weightedList.entries.findIndex(
       (x) => x.level.username == username
     );
@@ -239,11 +238,10 @@ const queue = {
   },
 
   submittedlevel: async (username) => {
+    var list = await queue.list();
     if (current_level != undefined && current_level.username == username) {
       return 0;
     }
-
-    var list = await queue.list();
     var both = list.online.concat(list.offline);
     var index = both.findIndex((x) => x.username == username);
     if (index != -1) {
@@ -253,6 +251,7 @@ const queue = {
   },
 
   weightedchance: async (displayName, username) => {
+    const weightedList = await queue.weightedList(false);
     if (current_level != undefined && current_level.submitter == displayName) {
       return 0;
     }
@@ -262,8 +261,6 @@ const queue = {
     if (twitch.checkLurk(username)) {
       return -2;
     }
-
-    const weightedList = await queue.weightedList(false);
 
     if (weightedList.entries.length == 0) {
       return -1;

--- a/tests/weight.test.js
+++ b/tests/weight.test.js
@@ -41,7 +41,7 @@ test("weight test", async () => {
   const twitch = index.twitch;
 
   let list;
-  list = await queue.weightedList();
+  list = queue.weightedList(await queue.list());
   expect(list.totalWeight).toBe(0);
   expect(list.offlineLength).toBe(0);
   expect(list.entries).toHaveLength(0);
@@ -63,7 +63,7 @@ test("weight test", async () => {
   expect(added).toContain("has been added to the queue");
 
   // no one is online yet!
-  list = await queue.weightedList();
+  list = queue.weightedList(await queue.list());
   expect(list.totalWeight).toBe(0);
   expect(list.offlineLength).toBe(3);
   expect(list.entries).toHaveLength(0);
@@ -71,7 +71,7 @@ test("weight test", async () => {
   // user 2 is now online
   twitch.noticeChatter(testUser2);
 
-  list = await queue.weightedList();
+  list = queue.weightedList(await queue.list());
   expect(list.totalWeight).toBe(1);
   expect(list.offlineLength).toBe(2);
   expect(list.entries).toHaveLength(1);
@@ -91,7 +91,7 @@ test("weight test", async () => {
   // now user 1 is online too
   twitch.noticeChatter(testUser1);
 
-  list = await queue.weightedList();
+  list = queue.weightedList(await queue.list());
   expect(list.totalWeight).toBe(12); // total weight is now 12
   expect(list.offlineLength).toBe(1);
   expect(list.entries).toHaveLength(2);

--- a/tests/weight.test.js
+++ b/tests/weight.test.js
@@ -40,11 +40,12 @@ test("weight test", async () => {
   const queue = index.quesoqueue;
   const twitch = index.twitch;
 
-  let list;
-  list = queue.weightedList(await queue.list());
-  expect(list.totalWeight).toBe(0);
-  expect(list.offlineLength).toBe(0);
-  expect(list.entries).toHaveLength(0);
+  await queue.withList((onlineOfflineList) => {
+    const list = queue.weightedList(onlineOfflineList);
+    expect(list.totalWeight).toBe(0);
+    expect(list.offlineLength).toBe(0);
+    expect(list.entries).toHaveLength(0);
+  });
 
   const testUser1 = buildChatter("test_user_1", "にゃん", false, false, false);
   const testUser2 = buildChatter("test_user_2", "にゃ", false, false, false);
@@ -63,24 +64,27 @@ test("weight test", async () => {
   expect(added).toContain("has been added to the queue");
 
   // no one is online yet!
-  list = queue.weightedList(await queue.list());
-  expect(list.totalWeight).toBe(0);
-  expect(list.offlineLength).toBe(3);
-  expect(list.entries).toHaveLength(0);
+  await queue.withList((onlineOfflineList) => {
+    const list = queue.weightedList(onlineOfflineList);
+    expect(list.totalWeight).toBe(0);
+    expect(list.offlineLength).toBe(3);
+    expect(list.entries).toHaveLength(0);
+  });
 
   // user 2 is now online
   twitch.noticeChatter(testUser2);
 
-  list = queue.weightedList(await queue.list());
-  expect(list.totalWeight).toBe(1);
-  expect(list.offlineLength).toBe(2);
-  expect(list.entries).toHaveLength(1);
-  let entry;
-  entry = list.entries[0];
-  expect(entry.level).toEqual(level2);
-  // position is 0 even though its oflline position is 1 (index), but it is position 0 for the online position
-  expect(entry.position).toBe(0);
-  expect(entry.weight()).toBe(1);
+  await queue.withList((onlineOfflineList) => {
+    const list = queue.weightedList(onlineOfflineList);
+    expect(list.totalWeight).toBe(1);
+    expect(list.offlineLength).toBe(2);
+    expect(list.entries).toHaveLength(1);
+    const entry = list.entries[0];
+    expect(entry.level).toEqual(level2);
+    // position is 0 even though its oflline position is 1 (index), but it is position 0 for the online position
+    expect(entry.position).toBe(0);
+    expect(entry.weight()).toBe(1);
+  });
 
   // keep user 2 online
   simSetChatters({ viewers: [testUser2.username] });
@@ -91,16 +95,18 @@ test("weight test", async () => {
   // now user 1 is online too
   twitch.noticeChatter(testUser1);
 
-  list = queue.weightedList(await queue.list());
-  expect(list.totalWeight).toBe(12); // total weight is now 12
-  expect(list.offlineLength).toBe(1);
-  expect(list.entries).toHaveLength(2);
-  entry = list.entries[0];
-  expect(entry.level).toEqual(level2);
-  expect(entry.position).toBe(1); // level 1 was submitted before level 2
-  expect(entry.weight()).toBe(11); // gained +10 weight
-  entry = list.entries[1];
-  expect(entry.level).toEqual(level1);
-  expect(entry.position).toBe(0); // level 1 was submitted before level 2
-  expect(entry.weight()).toBe(1);
+  await queue.withList((onlineOfflineList) => {
+    const list = queue.weightedList(onlineOfflineList);
+    expect(list.totalWeight).toBe(12); // total weight is now 12
+    expect(list.offlineLength).toBe(1);
+    expect(list.entries).toHaveLength(2);
+    let entry = list.entries[0];
+    expect(entry.level).toEqual(level2);
+    expect(entry.position).toBe(1); // level 1 was submitted before level 2
+    expect(entry.weight()).toBe(11); // gained +10 weight
+    entry = list.entries[1];
+    expect(entry.level).toEqual(level1);
+    expect(entry.position).toBe(0); // level 1 was submitted before level 2
+    expect(entry.weight()).toBe(1);
+  });
 });


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you run `eslint` on the code and resolved any errors?
- [x] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

The queue can crash in certain cases when using the `!chance` command.

The problem is the following:
`weightedList` is called here:
https://github.com/fluid-queue/fluid-queue/blob/7972e9d417de1b2c8997bc88e09c4db0957e2b42/src/queue.js#L266
and then after the `await`, the `weight` function is called here:
https://github.com/fluid-queue/fluid-queue/blob/7972e9d417de1b2c8997bc88e09c4db0957e2b42/src/queue.js#L285
But since there has been an `await`, there can be a chance that `!level` is being used between calculating the `weightedList` and accessing that list after the `await`.
This results into someone being in the `weightedList` while being picked, resulting in their weight to be removed!
The `weight` function then crashes the queue here:
https://github.com/fluid-queue/fluid-queue/blob/7972e9d417de1b2c8997bc88e09c4db0957e2b42/src/queue.js#L494-L504
That is because `waiting[level.username]` is `undefined`.
The list is filtered with `Object.prototype.hasOwnProperty.call(waiting, level.username)`, but this happens before the `await`, and this means that the data could change.

#### Solution

The solution is to read queue state (`current_level`, `levels`, `waiting`) and write to queue state in one synchronous block of code, and never have asynchronous code in-between those actions.
With this strategy it is guaranteed that the state is always consistent.

For example an online-offline list of levels is created and it used to be that this list is returned asynchronously (by using `await`), in those instances this online-offline list could actually be inconsistent compared to the queue state (`current_level`, `levels`, `waiting`)!

### Benefits

Queue does not crash on race conditions.

### Potential drawbacks

Worse maintainability and also it is difficult to verify that no race conditions are in the code.

I created no tests for this and changed a lot of functions, where some of them might not even be tested.

### Further notes and questions

I increased the version to `2.0.0-beta.2` and run `npm install` to update the versions in `package-lock.json` and this PR merges directly into `main`.

Will we create a new release from `main` after the merge?
