### PR TITLE
Remove dashes when printing an OCW code, and update tests to expect that

### DIFF
--- a/settings/settings.example.json
+++ b/settings/settings.example.json
@@ -29,7 +29,7 @@
     "ocw-lenient",
     "customlevel-name"
   ],
-  "resolverOptions": {
+  "extensionOptions": {
     "ocw": {
       "removeDashes": "true"
     }

--- a/settings/settings.example.json
+++ b/settings/settings.example.json
@@ -28,5 +28,10 @@
     "smm2-lenient",
     "ocw-lenient",
     "customlevel-name"
-  ]
+  ],
+  "resolverOptions": {
+    "ocw": {
+      "removeDashes": "true"
+    }
+  }
 }

--- a/src/extensions/ocw.ts
+++ b/src/extensions/ocw.ts
@@ -66,7 +66,16 @@ const codeSuffix = (levelCode: string) => {
 };
 
 function display(code: string) {
-  return code.replaceAll("-", "") + codeSuffix(code);
+  let codeDisplay = code;
+  if (
+    settings.resolverOptions &&
+    settings.resolverOptions.ocw &&
+    (settings.resolverOptions.ocw.removeDashes == "true" ||
+      settings.resolverOptions.ocw.removeDashes == "yes")
+  ) {
+    codeDisplay = code.replaceAll("-", "");
+  }
+  return codeDisplay + codeSuffix(code);
 }
 
 function resolver(args: string) {

--- a/src/extensions/ocw.ts
+++ b/src/extensions/ocw.ts
@@ -68,10 +68,10 @@ const codeSuffix = (levelCode: string) => {
 function display(code: string) {
   let codeDisplay = code;
   if (
-    settings.resolverOptions &&
-    settings.resolverOptions.ocw &&
-    (settings.resolverOptions.ocw.removeDashes == "true" ||
-      settings.resolverOptions.ocw.removeDashes == "yes")
+    settings.extensionOptions &&
+    settings.extensionOptions.ocw &&
+    (settings.extensionOptions.ocw.removeDashes == "true" ||
+      settings.extensionOptions.ocw.removeDashes == "yes")
   ) {
     codeDisplay = code.replaceAll("-", "");
   }

--- a/src/extensions/ocw.ts
+++ b/src/extensions/ocw.ts
@@ -66,7 +66,7 @@ const codeSuffix = (levelCode: string) => {
 };
 
 function display(code: string) {
-  return code + codeSuffix(code);
+  return code.replaceAll("-", "") + codeSuffix(code);
 }
 
 function resolver(args: string) {

--- a/src/settings-type.ts
+++ b/src/settings-type.ts
@@ -141,7 +141,7 @@ export const Settings = z
       )
       .nullable()
       .default(null),
-    resolverOptions: z
+    extensionOptions: z
       .record(z.string(), z.record(z.string(), z.string()))
       .describe("any options for your enabled resolvers")
       .nullable()

--- a/src/settings-type.ts
+++ b/src/settings-type.ts
@@ -141,5 +141,10 @@ export const Settings = z
       )
       .nullable()
       .default(null),
+    resolverOptions: z
+      .record(z.string(), z.record(z.string(), z.string()))
+      .describe("any options for your enabled resolvers")
+      .nullable()
+      .default(null),
   })
   .strict();

--- a/tests/chat-logs/chat/ocw.test.log
+++ b/tests/chat-logs/chat/ocw.test.log
@@ -23,7 +23,7 @@ chatters {"_links":{},"chatter_count":4,"chatters":{"broadcaster":["liquidnya"],
 [20:29:54] @^helperblock: liquidnya, that is an invalid level code.
 
 # configure ocw
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"]}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"resolverOptions":{"ocw":{"removeDashes": "true"}}}
 # restart to reload settings
 restart
 
@@ -41,7 +41,7 @@ restart
 # [20:36:21] @^helperblock: liquidnya, RHCD08CC8 (OCW) has been added to the queue.
 
 # showMakerCode
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"]}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"resolverOptions":{"ocw":{"removeDashes": "true"}}}
 # restart to reload settings
 restart
 
@@ -49,3 +49,13 @@ restart
 [20:32:16] @^helperblock: liquidnya, N41Q4WHD5 (OCW level code) has been added to the queue.
 [20:32:21] ~%?liquidnya: !add RHC-D08-CC8
 [20:32:21] @^helperblock: liquidnya, RHCD08CC8 (OCW maker code) has been added to the queue.
+
+# removeDashes off
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"resolverOptions":{"ocw":{"removeDashes": "false"}}}
+# restart to reload settings
+restart
+
+[20:32:15] ~%?liquidnya: !add N41-Q4W-HD5
+[20:32:16] @^helperblock: liquidnya, N41-Q4W-HD5 (OCW level code) has been added to the queue.
+[20:32:21] ~%?liquidnya: !add RHC-D08-CC8
+[20:32:21] @^helperblock: liquidnya, RHC-D08-CC8 (OCW maker code) has been added to the queue.

--- a/tests/chat-logs/chat/ocw.test.log
+++ b/tests/chat-logs/chat/ocw.test.log
@@ -2,7 +2,7 @@
 chatbot helperblock
 
 settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false}
-# chatters 
+# chatters
 chatters {"_links":{},"chatter_count":4,"chatters":{"broadcaster":["liquidnya"],"vips":[],"moderators":["furretwalkbot","streamelements"],"staff":[],"admins":[],"global_mods":[],"viewers":["viewerlevels"]}}
 # chatty chat log
 # ~ broadcaster
@@ -29,16 +29,16 @@ restart
 
 # now it is working!
 [20:32:15] ~%?liquidnya: !add N41-Q4W-HD5
-[20:32:16] @^helperblock: liquidnya, N41-Q4W-HD5 (OCW) has been added to the queue.
+[20:32:16] @^helperblock: liquidnya, N41Q4WHD5 (OCW) has been added to the queue.
 [20:32:21] ~%?liquidnya: !add RHC-D08-CC8
-[20:32:21] @^helperblock: liquidnya, RHC-D08-CC8 (OCW) has been added to the queue.
+[20:32:21] @^helperblock: liquidnya, RHCD08CC8 (OCW) has been added to the queue.
 
 # also check if ocw-lenient is working
 # FIXME: this is not working yet, because not all matches are checked
 # [20:36:15] ~%?liquidnya: !add please play this level N41-Q4W-HD5 thank you!
-# [20:36:16] @^helperblock: liquidnya, N41-Q4W-HD5 (OCW) has been added to the queue.
+# [20:36:16] @^helperblock: liquidnya, N41Q4WHD5 (OCW) has been added to the queue.
 # [20:36:21] ~%?liquidnya: !add please play this level RHC-D08-CC8 thank you!
-# [20:36:21] @^helperblock: liquidnya, RHC-D08-CC8 (OCW) has been added to the queue.
+# [20:36:21] @^helperblock: liquidnya, RHCD08CC8 (OCW) has been added to the queue.
 
 # showMakerCode
 settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"]}
@@ -46,6 +46,6 @@ settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"l
 restart
 
 [20:32:15] ~%?liquidnya: !add N41-Q4W-HD5
-[20:32:16] @^helperblock: liquidnya, N41-Q4W-HD5 (OCW level code) has been added to the queue.
+[20:32:16] @^helperblock: liquidnya, N41Q4WHD5 (OCW level code) has been added to the queue.
 [20:32:21] ~%?liquidnya: !add RHC-D08-CC8
-[20:32:21] @^helperblock: liquidnya, RHC-D08-CC8 (OCW maker code) has been added to the queue.
+[20:32:21] @^helperblock: liquidnya, RHCD08CC8 (OCW maker code) has been added to the queue.

--- a/tests/chat-logs/chat/ocw.test.log
+++ b/tests/chat-logs/chat/ocw.test.log
@@ -23,7 +23,7 @@ chatters {"_links":{},"chatter_count":4,"chatters":{"broadcaster":["liquidnya"],
 [20:29:54] @^helperblock: liquidnya, that is an invalid level code.
 
 # configure ocw
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"resolverOptions":{"ocw":{"removeDashes": "true"}}}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "true"}}}
 # restart to reload settings
 restart
 
@@ -41,7 +41,7 @@ restart
 # [20:36:21] @^helperblock: liquidnya, RHCD08CC8 (OCW) has been added to the queue.
 
 # showMakerCode
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"resolverOptions":{"ocw":{"removeDashes": "true"}}}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "true"}}}
 # restart to reload settings
 restart
 
@@ -51,7 +51,7 @@ restart
 [20:32:21] @^helperblock: liquidnya, RHCD08CC8 (OCW maker code) has been added to the queue.
 
 # removeDashes off
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"resolverOptions":{"ocw":{"removeDashes": "false"}}}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "false"}}}
 # restart to reload settings
 restart
 


### PR DESCRIPTION
### Checklist

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you run `eslint` on the code and resolved any errors?
- [X] Have you run `npm test` and all tests are passing?
- [X] Have you added new tests for any new functions created?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

Remove dashes from OCW level codes when printing them (closes #62).

### Benefits

Easier copy and paste of OCW codes.

### Potential drawbacks

Harder to read the codes?
