### PR TITLE
Hotfix/submitted command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [2.0.0-beta.3]
+
+## Bug fixes
+
+- Fix a bug where the `!submitted` command was not working (#67)
+
 # [2.0.0-beta.2]
 
 ## Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fluid-queue",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fluid-queue",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-beta.3",
       "license": "GPL-3.0",
       "dependencies": {
         "@twurple/api": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluid-queue",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "A queue system for Super Mario Maker 2 levels",
   "homepage": "https://fluid-queue.dev/",
   "bugs": {

--- a/src/index.js
+++ b/src/index.js
@@ -814,7 +814,7 @@ async function HandleMessage(message, sender, respond) {
   } else if (aliases.isAlias("submitted", message)) {
     respond(
       submitted_message(
-        quesoqueue.submittedlevel(sender.username),
+        await quesoqueue.submittedlevel(sender.username),
         sender.displayName
       )
     );

--- a/tests/chat-logs/chat/add.test.log
+++ b/tests/chat-logs/chat/add.test.log
@@ -76,3 +76,22 @@ queue.json/queue [{"code":"MY2-H2M-DSG","type":"smm2","submitter":"FurretWalkBot
 # lowercase level codes without dashes work
 [02:24:35] ~%?liquidnya: !add nb01mdslg
 [02:24:35] @^helperblock: liquidnya, NB0-1MD-SLG has been added to the queue.
+
+# test !submitted command
+[02:24:45] ~%?liquidnya: !submitted
+[02:24:45] @^helperblock: liquidnya, you have submitted NB0-1MD-SLG to the queue.
+
+[02:24:45] ~%?liquidnya: !remove liquidnya
+[02:24:45] @^helperblock: liquidnya's level has been removed from the queue.
+
+[02:24:45] ~%?liquidnya: !submitted
+[02:24:45] @^helperblock: liquidnya, looks like you're not in the queue. Try !add XXX-XXX-XXX.
+
+[02:25:13] @^FurretWalkBot: !add MY2-H2M-DSG
+[02:25:13] @^helperblock: FurretWalkBot, MY2-H2M-DSG has been added to the queue.
+
+[02:25:29] ~%?liquidnya: !next
+[02:25:31] @^helperblock: Now playing MY2-H2M-DSG submitted by FurretWalkBot.
+
+[02:25:34] @^FurretWalkBot: !submitted
+[02:25:34] @^helperblock: Your level is being played right now!


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you run `eslint` on the code and resolved any errors?
- [x] Have you run `npm test` and all tests are passing?
- [x] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

Fixes a bug where the `!submitted` command was not working.
This was introduced by #63 since the `submittedlevel` function was changed to being `async` but `await` was missing on the caller site.

I also added test cases for the `!submitted` command to the `add.test.log`.

### Benefits

The `!submitted` command works again.

### Potential drawbacks

As far as I know: none.
