### PR TITLE
Run Dependabot on develop instead of main

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0 # This restricts it to security updates only
+    target-branch: "develop" # If it's an urgent update, we can hotfix on main directly
+    pull-request-branch-name:
+      separator: "/"
+    reviewers: # Might as well drag us in if there's a security update
+      - "demize"
+      - "liquidnya"
+    versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
### Checklist

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you run `eslint` on the code and resolved any errors? -- N/A
- [X] Have you run `npm test` and all tests are passing? -- N/A
- [X] Have you added new tests for any new functions created? -- N/A
- [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading? -- N/A

### Description

Dependabot helpfully checks for security updates for us, but it bases them on `main`. Given our workflow tries to avoid committing directly to `main`, I think it's better if we let it base its changes on `develop`, and manually push out a hotfix if a security update warrants.

### Benefits

Better Dependabot integration into our workflow. Faster merging of security updates without needing to worry about `main`, especially as it assigns both myself and @liquidnya as reviewers with this config. A bit of battle-testing for any security updates before they make it to `main`.

### Potential drawbacks

This does mean more of a delay getting security updates onto main (unless we push a hotfix), though I feel that's a bit mitigated by the increased chance we'll merge into develop quickly.