### PR TITLE
Load extensions using a "file://" scheme to fix a crash on Windows

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -125,7 +125,11 @@ const loadExtensionModules = async (
 
   const importModules: Promise<{ name: string; module: object }>[] =
     moduleFiles.map(async ({ name, fileName }) => {
-      const importName = "file:\\\\" + path.join(directory, fileName);
+      let prefix = "";
+      if (process.platform === "win32") {
+        prefix = "file://";
+      }
+      const importName = prefix + path.join(directory, fileName);
       const module = await import(importName);
       return { name, module };
     });

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -125,7 +125,7 @@ const loadExtensionModules = async (
 
   const importModules: Promise<{ name: string; module: object }>[] =
     moduleFiles.map(async ({ name, fileName }) => {
-      const importName = path.join(directory, fileName);
+      const importName = "file:\\\\" + path.join(directory, fileName);
       const module = await import(importName);
       return { name, module };
     });


### PR DESCRIPTION
```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file and data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

I think that error says it all. This fixes this crash.

### Checklist

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you run `eslint` on the code and resolved any errors?
- [X] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created? -- No new tests
- [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?