### PR TITLE
Moderator !entry command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
   however the queue will still use the previous display name whenever the level is displayed in chat.
 - Moderators and the broadcaster can now use the moderator `!entry <username>` command to show the queue entry of someone else.
 
+## Bug fixes
+
+- You no longer get the message `your level has been removed from the queue` when you use `!leave` and do not have a level in the queue.
+
+## Other changes
+
+- The broadcaster can now use `!leave` and `!remove` without an argument to remove their own levels.
+
 # [2.0.0-beta.3]
 
 ## Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Usage of user ids instead of usernames for the queue save file as well as internal state of the queue.
   This means that if someone renames themselves that they will still keep their queue entry as well as their waiting time,
   however the queue will still use the previous display name whenever the level is displayed in chat.
+- Moderators and the broadcaster can now use the moderator `!entry <username>` command to show the queue entry of someone else.
 
 # [2.0.0-beta.3]
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,17 +238,25 @@ const submitted_message = async (
 };
 
 const submitted_mod_message = async (
-  level: QueueEntry | number,
+  submitted:
+    | { result: "no-submitter" | "not-found" }
+    | { result: "current" | "level"; level: QueueEntry },
   usernameArgument: string
 ) => {
-  if (level === 0) {
-    return `${usernameArgument}'s level is being played right now!`;
-  } else if (level === -1) {
+  if (submitted.result == "current") {
+    return `${submitted.level.submitter}'s level is being played right now!`;
+  } else if (submitted.result == "not-found") {
     return `${usernameArgument} is not in the queue.`;
-  } else if (typeof level === "number") {
-    return "You can use !submitted <username> to view someones entry.";
+  } else if (submitted.result == "level") {
+    return (
+      submitted.level.submitter +
+      " has submitted " +
+      submitted.level +
+      " to the queue."
+    );
   }
-  return level.submitter + " has submitted " + level + " to the queue.";
+
+  return "You can use !submitted <username> to view someones entry.";
 };
 
 // What the bot should do when someone sends a message in chat.
@@ -732,7 +740,7 @@ async function HandleMessage(
       const usernameArgument = get_remainder(message);
       respond(
         await submitted_mod_message(
-          await quesoqueue.submittedlevel(usernameArgument),
+          quesoqueue.modSubmittedLevel(usernameArgument),
           usernameArgument
         )
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ function get_remainder(x: string) {
   if (index == -1) {
     return "";
   }
-  return x.substring(index + 1);
+  return x.substring(index + 1).trim();
 }
 
 let can_list = true;
@@ -489,8 +489,8 @@ async function HandleMessage(
       respond("Sorry, the queue is closed right now.");
     }
   } else if (aliases.isAlias("remove", message)) {
-    if (sender.isBroadcaster) {
-      const to_remove = get_remainder(message);
+    const to_remove = get_remainder(message);
+    if (sender.isBroadcaster && to_remove != "") {
       respond(quesoqueue.modRemove(to_remove));
     } else {
       // if they're leaving, they're not lurking
@@ -736,8 +736,8 @@ async function HandleMessage(
       )
     );
   } else if (aliases.isAlias("submitted", message)) {
-    if (sender.isMod || sender.isBroadcaster) {
-      const usernameArgument = get_remainder(message);
+    const usernameArgument = get_remainder(message);
+    if ((sender.isMod || sender.isBroadcaster) && usernameArgument != "") {
       respond(
         await submitted_mod_message(
           quesoqueue.modSubmittedLevel(usernameArgument),

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,6 +237,20 @@ const submitted_message = async (
   return sender + ", you have submitted " + level + " to the queue.";
 };
 
+const submitted_mod_message = async (
+  level: QueueEntry | number,
+  usernameArgument: string
+) => {
+  if (level === 0) {
+    return `${usernameArgument}'s level is being played right now!`;
+  } else if (level === -1) {
+    return `${usernameArgument} is not in the queue.`;
+  } else if (typeof level === "number") {
+    return "You can use !submitted <username> to view someones entry.";
+  }
+  return level.submitter + " has submitted " + level + " to the queue.";
+};
+
 // What the bot should do when someone sends a message in chat.
 // `message` is the full text of the message. `sender` is the username
 // of the person that sent the message.
@@ -714,9 +728,19 @@ async function HandleMessage(
       )
     );
   } else if (aliases.isAlias("submitted", message)) {
-    respond(
-      await submitted_message(await quesoqueue.submittedlevel(sender), sender)
-    );
+    if (sender.isMod || sender.isBroadcaster) {
+      const usernameArgument = get_remainder(message);
+      respond(
+        await submitted_mod_message(
+          await quesoqueue.submittedlevel(usernameArgument),
+          usernameArgument
+        )
+      );
+    } else {
+      respond(
+        await submitted_message(await quesoqueue.submittedlevel(sender), sender)
+      );
+    }
   } else if (
     settings.level_timeout &&
     level_timer != null &&

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -345,6 +345,9 @@ const queue = {
         data.levels,
         queue.matchSubmitter(submitter)
       );
+      if (removedLevels.length === 0) {
+        return `${submitter}, looks like you're not in the queue. Try !add XXX-XXX-XXX.`;
+      }
       data.onRemove(removedLevels);
       data.saveLater();
       return `${submitter}, your level has been removed from the queue.`;

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -456,7 +456,26 @@ const queue = {
     });
   },
 
-  submittedlevel: async (submitter: QueueSubmitter) => {
+  submittedlevel: async (submitter: QueueSubmitter | string) => {
+    if (typeof submitter === "string") {
+      if (submitter == "") {
+        return -2;
+      }
+      return data.access((data) => {
+        if (
+          data.current_level != undefined &&
+          queue.matchUsernameArgument(submitter)(data.current_level)
+        ) {
+          return 0;
+        }
+        const level = data.levels.find(queue.matchUsernameArgument(submitter));
+        if (level !== undefined) {
+          return level;
+        } else {
+          return -1;
+        }
+      });
+    }
     const getList = await queue.list();
     return data.access((data) => {
       if (

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -456,26 +456,31 @@ const queue = {
     });
   },
 
-  submittedlevel: async (submitter: QueueSubmitter | string) => {
-    if (typeof submitter === "string") {
-      if (submitter == "") {
-        return -2;
-      }
-      return data.access((data) => {
-        if (
-          data.current_level != undefined &&
-          queue.matchUsernameArgument(submitter)(data.current_level)
-        ) {
-          return 0;
-        }
-        const level = data.levels.find(queue.matchUsernameArgument(submitter));
-        if (level !== undefined) {
-          return level;
-        } else {
-          return -1;
-        }
-      });
+  modSubmittedLevel: (
+    submitter: string
+  ):
+    | { result: "no-submitter" | "not-found" }
+    | { result: "current" | "level"; level: QueueEntry } => {
+    if (submitter == "") {
+      return { result: "no-submitter" };
     }
+    return data.access((data) => {
+      if (
+        data.current_level != undefined &&
+        queue.matchUsernameArgument(submitter)(data.current_level)
+      ) {
+        return { result: "current", level: data.current_level };
+      }
+      const level = data.levels.find(queue.matchUsernameArgument(submitter));
+      if (level !== undefined) {
+        return { result: "level", level };
+      } else {
+        return { result: "not-found" };
+      }
+    });
+  },
+
+  submittedlevel: async (submitter: QueueSubmitter) => {
     const getList = await queue.list();
     return data.access((data) => {
       if (

--- a/tests/chat-logs/chat/add.test.log
+++ b/tests/chat-logs/chat/add.test.log
@@ -98,3 +98,31 @@ queue.json/entries/queue [{"code":"MY2-H2M-DSG","type":"smm2","submitter":{"id":
 
 [02:25:34] @^FurretWalkBot: !submitted @furretwalkbot
 [02:25:34] @^helperblock: FurretWalkBot's level is being played right now!
+
+# !entry argument is needed as a moderator
+
+[02:26:34] @^FurretWalkBot: !submitted
+[02:26:34] @^helperblock: You can use !submitted <username> to view someones entry.
+
+# unmodded FurretWalkBot
+
+[02:27:34] ^FurretWalkBot: !submitted
+[02:27:34] @^helperblock: Your level is being played right now!
+
+[02:28:45] ~%?liquidnya: !dismiss
+[02:28:45] @^helperblock: Dismissed MY2-H2M-DSG submitted by FurretWalkBot.
+
+[02:29:34] ^FurretWalkBot: !submitted
+[02:29:34] @^helperblock: FurretWalkBot, looks like you're not in the queue. Try !add XXX-XXX-XXX.
+
+[02:30:45] ~%?liquidnya: !submitted @FurretWalkBot
+[02:30:45] @^helperblock: @FurretWalkBot is not in the queue.
+
+[03:25:13] ^FurretWalkBot: !add 3H7-B19-7RF
+[03:25:13] @^helperblock: FurretWalkBot, 3H7-B19-7RF has been added to the queue.
+
+[03:29:34] ^FurretWalkBot: !submitted
+[03:29:34] @^helperblock: FurretWalkBot, you have submitted 3H7-B19-7RF to the queue.
+
+[03:30:45] ~%?liquidnya: !submitted furretwalkbot
+[03:30:45] @^helperblock: FurretWalkBot has submitted 3H7-B19-7RF to the queue.

--- a/tests/chat-logs/chat/add.test.log
+++ b/tests/chat-logs/chat/add.test.log
@@ -78,14 +78,14 @@ queue.json/entries/queue [{"code":"MY2-H2M-DSG","type":"smm2","submitter":{"id":
 [02:24:35] @^helperblock: liquidnya, NB0-1MD-SLG has been added to the queue.
 
 # test !submitted command
-[02:24:45] ~%?liquidnya: !submitted
-[02:24:45] @^helperblock: liquidnya, you have submitted NB0-1MD-SLG to the queue.
+[02:24:45] ~%?liquidnya: !submitted liquidnya
+[02:24:45] @^helperblock: liquidnya has submitted NB0-1MD-SLG to the queue.
 
 [02:24:45] ~%?liquidnya: !remove liquidnya
 [02:24:45] @^helperblock: liquidnya's level has been removed from the queue.
 
-[02:24:45] ~%?liquidnya: !submitted
-[02:24:45] @^helperblock: liquidnya, looks like you're not in the queue. Try !add XXX-XXX-XXX.
+[02:24:45] ~%?liquidnya: !submitted liquidnya
+[02:24:45] @^helperblock: liquidnya is not in the queue.
 
 [02:25:13] @^FurretWalkBot: !add MY2-H2M-DSG
 [02:25:13] @^helperblock: FurretWalkBot, MY2-H2M-DSG has been added to the queue.
@@ -93,5 +93,8 @@ queue.json/entries/queue [{"code":"MY2-H2M-DSG","type":"smm2","submitter":{"id":
 [02:25:29] ~%?liquidnya: !next
 [02:25:31] @^helperblock: Now playing MY2-H2M-DSG submitted by FurretWalkBot.
 
-[02:25:34] @^FurretWalkBot: !submitted
-[02:25:34] @^helperblock: Your level is being played right now!
+[02:25:34] @^FurretWalkBot: !submitted FurretWalkBot
+[02:25:34] @^helperblock: FurretWalkBot's level is being played right now!
+
+[02:25:34] @^FurretWalkBot: !submitted furretwalkbot
+[02:25:34] @^helperblock: furretwalkbot's level is being played right now!

--- a/tests/chat-logs/chat/add.test.log
+++ b/tests/chat-logs/chat/add.test.log
@@ -126,3 +126,8 @@ queue.json/entries/queue [{"code":"MY2-H2M-DSG","type":"smm2","submitter":{"id":
 
 [03:30:45] ~%?liquidnya: !submitted furretwalkbot
 [03:30:45] @^helperblock: FurretWalkBot has submitted 3H7-B19-7RF to the queue.
+
+# if you are not a mod (or broadcaster) you can not query other peoples levels
+
+[03:29:34] ^FurretWalkBot: !submitted liquidnya
+[03:29:34] @^helperblock: FurretWalkBot, you have submitted 3H7-B19-7RF to the queue.

--- a/tests/chat-logs/chat/add.test.log
+++ b/tests/chat-logs/chat/add.test.log
@@ -99,10 +99,10 @@ queue.json/entries/queue [{"code":"MY2-H2M-DSG","type":"smm2","submitter":{"id":
 [02:25:34] @^FurretWalkBot: !submitted @furretwalkbot
 [02:25:34] @^helperblock: FurretWalkBot's level is being played right now!
 
-# !entry argument is needed as a moderator
+# !entry argument is not needed as a moderator
 
 [02:26:34] @^FurretWalkBot: !submitted
-[02:26:34] @^helperblock: You can use !submitted <username> to view someones entry.
+[02:26:34] @^helperblock: Your level is being played right now!
 
 # unmodded FurretWalkBot
 
@@ -131,3 +131,17 @@ queue.json/entries/queue [{"code":"MY2-H2M-DSG","type":"smm2","submitter":{"id":
 
 [03:29:34] ^FurretWalkBot: !submitted liquidnya
 [03:29:34] @^helperblock: FurretWalkBot, you have submitted 3H7-B19-7RF to the queue.
+
+[03:30:13] ~%?liquidnya: !clear
+[03:30:14] @^helperblock: The queue has been cleared!
+
+# !remove/!leave can be used without an argument as the broadcaster
+
+[04:25:29] ~%?liquidnya: !leave
+[04:25:31] @^helperblock: liquidnya, looks like you're not in the queue. Try !add XXX-XXX-XXX.
+
+[04:26:35] ~%?liquidnya: !add nb01mdslg
+[04:26:35] @^helperblock: liquidnya, NB0-1MD-SLG has been added to the queue.
+
+[04:27:29] ~%?liquidnya: !leave
+[04:27:31] @^helperblock: liquidnya, your level has been removed from the queue.

--- a/tests/chat-logs/chat/add.test.log
+++ b/tests/chat-logs/chat/add.test.log
@@ -96,5 +96,5 @@ queue.json/entries/queue [{"code":"MY2-H2M-DSG","type":"smm2","submitter":{"id":
 [02:25:34] @^FurretWalkBot: !submitted FurretWalkBot
 [02:25:34] @^helperblock: FurretWalkBot's level is being played right now!
 
-[02:25:34] @^FurretWalkBot: !submitted furretwalkbot
-[02:25:34] @^helperblock: furretwalkbot's level is being played right now!
+[02:25:34] @^FurretWalkBot: !submitted @furretwalkbot
+[02:25:34] @^helperblock: FurretWalkBot's level is being played right now!

--- a/tests/chat-logs/chat/broadcaster-only.test.log
+++ b/tests/chat-logs/chat/broadcaster-only.test.log
@@ -19,14 +19,11 @@ chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # `!remove <username>` behaves like `!remove`
 
 [19:38:05] @^FurretWalkBot: !remove liquidnya
-[19:38:05] @^helperblock: FurretWalkBot, your level has been removed from the queue.
+[19:38:05] @^helperblock: FurretWalkBot, looks like you're not in the queue. Try !add XXX-XXX-XXX.
 [19:38:14] @^FurretWalkBot: !remove liquidnya
-[19:38:15] @^helperblock: FurretWalkBot, your level has been removed from the queue.
+[19:38:15] @^helperblock: FurretWalkBot, looks like you're not in the queue. Try !add XXX-XXX-XXX.
 [19:38:21] @^FurretWalkBot: !remove liquidnya
-[19:38:21] @^helperblock: FurretWalkBot, your level has been removed from the queue.
-
-# you can remove yourself even though you are not in the queue
-# TODO: is this a bug?
+[19:38:21] @^helperblock: FurretWalkBot, looks like you're not in the queue. Try !add XXX-XXX-XXX.
 
 [19:39:03] @^FurretWalkBot: !list
 [19:39:03] @^helperblock: 1 online: (no current level), liquidnya... (0 offline)


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you run `eslint` on the code and resolved any errors?
- [x] Have you run `npm test` and all tests are passing?
- [x] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

This fixes #7.
Added the `!entry <username>`/`!submitted <username>` command for moderators and the broadcaster to see what level someone else submitted.

### Benefits

It is easier to see the level codes of someone else.
For example maybe the streamer wanted to check out someones submission in game without `!select`ing them.

### Potential drawbacks

Moderators (and the broadcaster) needs to use `!entry <their own username>` to see their own entry.
If they use `!entry` then they see the message `You can use !submitted <username> to view someones entry.`
