### PR TITLE
Update CHANGELOG.md to include deprecated smm1_codes_enabled setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   Also make sure you have the dev dependencies installed before building the queue `NODE_ENV=development npm install`.
   You can also download a compiled version at <https://github.com/fluid-queue/fluid-queue/releases> or use the docker container to avoid building the sources.
 - Subscriber status, moderator status and BRB status (by using the `!brb` command) is only stored for 12 hours per user after which the status is reset.
+- The setting `smm1_codes_enabled` was removed and needs to be removed from `settings/settings.json`. If you want to use SMM1 levels, make sure to configure `"smm1"` as one of the resolvers for the `"resolvers"` setting instead.
 
 ## New features
 


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [ ] Have you run `eslint` on the code and resolved any errors?
- [ ] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

Updates the CHANGELOG.md to add the removed setting `smm1_codes_enabled` as a breaking change, since the queue will not start any more when that setting is set.

### Benefits

Users are not surprised by this change.

### Potential drawbacks

More to read through when checking the CHANGELOG.md.
