### PR TITLE
Update minimum node versions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,7 +6,7 @@ parser: "@typescript-eslint/parser"
 env:
   browser: false
   commonjs: false
-  es2021: true
+  es2022: true
   jest/globals: false
   node: true
 extends:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 19.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Run eslint and prettier --check with Node.js ${{ matrix.node-version }}
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 19.x]
+        node-version: [18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   You can also download a compiled version at <https://github.com/fluid-queue/fluid-queue/releases> or use the docker container to avoid building the sources.
 - Subscriber status, moderator status and BRB status (by using the `!brb` command) is only stored for 12 hours per user after which the status is reset.
 - The setting `smm1_codes_enabled` was removed and needs to be removed from `settings/settings.json`. If you want to use SMM1 levels, make sure to configure `"smm1"` as one of the resolvers for the `"resolvers"` setting instead.
+- The minimum node version is now `18.6.0` and the docker image is now build with node version `20`.
 
 ## New features
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19-alpine AS build
+FROM node:20-alpine AS build
 
 # We're building, this needs to be development
 ENV NODE_ENV=development
@@ -17,7 +17,7 @@ COPY . /build
 
 RUN sh -c "npm run build && cp -R /build/package.json /build/build /home/node"
 
-FROM node:19-alpine AS app
+FROM node:20-alpine AS app
 
 # For version information
 ARG SOURCE_COMMIT

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM node:19-alpine
+FROM node:20-alpine
 
 # For version information
 ARG SOURCE_COMMIT

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We test against the current LTS Node.JS version, and target the latest LTS versi
 $ git clone https://github.com/fluid-queue/fluid-queue.git
 $ cd fluid-queue
 $ git checkout develop # Only necessary if you're working on the develop branch
-$ npm install
+$ npm install --omit=optional # Optional dependencies are for tests; do --include=optional if you plan on running the tests
 $ npm run build
 $ npm run clean # If you need to clean up the build directory
 ```

--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ Most of our contributing guidelines can be found in [CONTRIBUTING.md](https://gi
 
 ### Building the bot
 
-Since we develop in Typescript, in order to run the bot, you need to build the bot. You should be able to do this fairly easily, as long as you have `git` and Node.JS installed:
+Since we develop in Typescript, in order to run the bot, you need to build the bot. You should be able to do this fairly easily, as long as you have `git` and Node.JS installed.
+We test against the current LTS Node.JS version, and target the latest LTS version. Make sure to use a compatible version of node which can be found in the `package.json` file.
 
 ```sh
 $ git clone https://github.com/fluid-queue/fluid-queue.git
 $ cd fluid-queue
 $ git checkout develop # Only necessary if you're working on the develop branch
-$ npm install --omit=optional # Optional dependencies are for tests; do --include=optional if you plan on running the tests
+$ npm install
 $ npm run build
 $ npm run clean # If you need to clean up the build directory
 ```

--- a/build.ts
+++ b/build.ts
@@ -11,7 +11,7 @@ await esbuild.build({
   bundle: true,
   outdir: "build/",
   format: "esm",
-  target: "node16.14.0",
+  target: "node16.17.0",
   platform: "node",
   banner: {
     js: `

--- a/build.ts
+++ b/build.ts
@@ -11,7 +11,7 @@ await esbuild.build({
   bundle: true,
   outdir: "build/",
   format: "esm",
-  target: "node16.17.0",
+  target: "node18.6.0",
   platform: "node",
   banner: {
     js: `

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "node": ">=16.17.0"
+        "node": "^16.17.0 || ^18.6.0 || >=19.0.0"
       },
       "optionalDependencies": {
         "@swc/core": "^1.3.55",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "devDependencies": {
         "@babel/code-frame": "^7.18.6",
         "@swc-node/register": "^1.6.5",
-        "@tsconfig/node16": "^1.0.3",
+        "@tsconfig/node18": "^1.0.3",
         "@types/babel__code-frame": "^7.0.3",
         "@types/node": "^18.15.11",
         "@types/tmi.js": "^1.8.3",
@@ -46,7 +46,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "node": "^16.17.0 || ^18.6.0 || >=19.0.0"
+        "node": "^18.6.0 || >=19.0.0"
       },
       "optionalDependencies": {
         "@swc/core": "^1.3.55",
@@ -2434,7 +2434,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "devOptional": true
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node18": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-1.0.3.tgz",
+      "integrity": "sha512-RbwvSJQsuN9TB04AQbGULYfOGE/RnSFk/FLQ5b0NmDf5Kx2q/lABZbHQPKCO1vZ6Fiwkplu+yb9pGdLy1iGseQ==",
+      "dev": true
     },
     "node_modules/@twurple/api": {
       "version": "6.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "node": ">=16.14.0"
+        "node": ">=16.17.0"
       },
       "optionalDependencies": {
         "@swc/core": "^1.3.55",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^5.0.4"
   },
   "engines": {
-    "node": ">=16.14.0"
+    "node": ">=16.17.0"
   },
   "optionalDependencies": {
     "@swc/core": "^1.3.55",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^5.0.4"
   },
   "engines": {
-    "node": ">=16.17.0"
+    "node": "^16.17.0 || ^18.6.0 || >=19.0.0"
   },
   "optionalDependencies": {
     "@swc/core": "^1.3.55",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@babel/code-frame": "^7.18.6",
     "@swc-node/register": "^1.6.5",
-    "@tsconfig/node16": "^1.0.3",
+    "@tsconfig/node18": "^1.0.3",
     "@types/babel__code-frame": "^7.0.3",
     "@types/node": "^18.15.11",
     "@types/tmi.js": "^1.8.3",
@@ -58,7 +58,7 @@
     "typescript": "^5.0.4"
   },
   "engines": {
-    "node": "^16.17.0 || ^18.6.0 || >=19.0.0"
+    "node": "^18.6.0 || >=19.0.0"
   },
   "optionalDependencies": {
     "@swc/core": "^1.3.55",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "outDir": "./build",
     "allowJs": false,
-    "module": "Node16",
-    "moduleResolution": "node16",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [ ] Have you run `eslint` on the code and resolved any errors?
- [ ] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

When running `npm run build` with node versions `16.14.0`, `16.15.0`, and `16.16.0` then the following error occurs:

```
node:internal/errors:465
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/nya/projects/fluid-queue/glob.js' imported from /home/nya/projects/fluid-queue/
    at new NodeError (node:internal/errors:372:5)
    at finalizeResolution (node:internal/modules/esm/resolve:437:11)
    at moduleResolve (node:internal/modules/esm/resolve:1009:10)
    at defaultResolve (node:internal/modules/esm/resolve:1218:11)
    at resolve (file:///home/nya/projects/fluid-queue/node_modules/@swc-node/register/esm/esm.mjs:78:12)
    at ESMLoader.resolve (node:internal/modules/esm/loader:580:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:294:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:80:40)
    at link (node:internal/modules/esm/module_job:78:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```

### Benefits

Building the project works with node version `16.17.0`.

### Potential drawbacks

Someone could still use node version `16.14.0`, but I could not find a different fix.
