### PR TITLE
Print for which extension i18next is initialized

### DIFF
--- a/src/extensions/customcode.ts
+++ b/src/extensions/customcode.ts
@@ -5,12 +5,9 @@ import * as persistence from "../persistence.js";
 import { Entry, PersistedEntry } from "../extensions-api/queue-entry.js";
 import { Result } from "../extensions-api/helpers.js";
 import { Chatter } from "../extensions-api/command.js";
-
 import i18next from "i18next";
-if (process && process.env && process.env.NODE_ENV != "test") {
-  await import("./helpers/i18n.js");
-}
-await i18next.loadNamespaces("customcode");
+
+await (await import("./helpers/i18n.js")).init("customcode");
 
 class CustomCodes {
   map: Map<string, { customCode: string; entry: Entry }> = new Map<

--- a/src/extensions/customlevel.ts
+++ b/src/extensions/customlevel.ts
@@ -9,14 +9,9 @@ import settings from "../settings.js";
 import { checkVersion } from "./helpers/version.js";
 import { v5 as uuidv5, v4 as uuidv4, validate as uuidValidate } from "uuid";
 import { z } from "zod";
-
 import i18next from "i18next";
-if (process && process.env && process.env.NODE_ENV != "test") {
-  // Tests are hecking weird, and don't need this, and break because of this
-  // This feels like a hack but it works
-  await import("./helpers/i18n.js");
-}
-await i18next.loadNamespaces("customlevel");
+
+await (await import("./helpers/i18n.js")).init("customlevel");
 
 const QUEUE_NAMESPACE = "1e511052-e714-49bb-8564-b60915cf7279"; // this is the namespace for *known* level types for the queue (Version 4 UUID)
 const ROMHACK_UUID = uuidv5("ROMhack", QUEUE_NAMESPACE);

--- a/src/extensions/helpers/i18n.ts
+++ b/src/extensions/helpers/i18n.ts
@@ -3,21 +3,31 @@ import FsBackend, { FsBackendOptions } from "i18next-fs-backend";
 import { join, dirname as pathDirname } from "path";
 import { fileURLToPath } from "url";
 import { readdirSync, lstatSync } from "fs";
-import { options } from "../../i18next-options.js";
 
-const dirname = pathDirname(fileURLToPath(import.meta.url));
+export async function init(extension: string) {
+  if (process && process.env && process.env.NODE_ENV != "test") {
+    const { options } = await import("../../i18next-options.js");
 
-console.log("Initializing i18next for extensions...");
-await i18next.use(FsBackend).init<FsBackendOptions>({
-  ...options,
-  backend: {
-    ...options.backend,
-    loadPath: join(dirname, "../../locales/{{lng}}/{{ns}}.json"),
-    addPath: join(dirname, "../../locales/{{lng}}/{{ns}}.missing.json"),
-  },
-  preload: readdirSync(join(dirname, "../../locales")).filter((fileName) => {
-    const joinedPath = join(join(dirname, "../../locales"), fileName);
-    const isDirectory = lstatSync(joinedPath).isDirectory();
-    return isDirectory;
-  }),
-});
+    // Tests are hecking weird, and don't need this, and break because of this
+    // This feels like a hack but it works
+    const dirname = pathDirname(fileURLToPath(import.meta.url));
+
+    console.log(`Initializing i18next for extension ${extension}...`);
+    await i18next.use(FsBackend).init<FsBackendOptions>({
+      ...options,
+      backend: {
+        ...options.backend,
+        loadPath: join(dirname, "../../locales/{{lng}}/{{ns}}.json"),
+        addPath: join(dirname, "../../locales/{{lng}}/{{ns}}.missing.json"),
+      },
+      preload: readdirSync(join(dirname, "../../locales")).filter(
+        (fileName) => {
+          const joinedPath = join(join(dirname, "../../locales"), fileName);
+          const isDirectory = lstatSync(joinedPath).isDirectory();
+          return isDirectory;
+        }
+      ),
+    });
+  }
+  await i18next.loadNamespaces(extension);
+}

--- a/src/extensions/ocw.ts
+++ b/src/extensions/ocw.ts
@@ -4,12 +4,9 @@ import {
   courseIdValidity as _courseIdValidity,
   CodeTypes,
 } from "./helpers/codeparsing.js";
-
 import i18next from "i18next";
-if (process && process.env && process.env.NODE_ENV != "test") {
-  await import("./helpers/i18n.js");
-}
-await i18next.loadNamespaces("ocw");
+
+await (await import("./helpers/i18n.js")).init("ocw");
 
 // Need a slightly different regex because we don't know what OCW IDs will end with
 // If anyone figures that out, we can update this, but it would still be different

--- a/src/extensions/smm2.ts
+++ b/src/extensions/smm2.ts
@@ -4,12 +4,9 @@ import {
   courseIdValidity as _courseIdValidity,
   CodeTypes,
 } from "./helpers/codeparsing.js";
-
 import i18next from "i18next";
-if (process && process.env && process.env.NODE_ENV != "test") {
-  await import("./helpers/i18n.js");
-}
-await i18next.loadNamespaces("smm2");
+
+await (await import("./helpers/i18n.js")).init("smm2");
 
 const delim = "[-. ]?";
 const code = "[A-Ha-hJ-Nj-nP-Yp-y0-9]{3}";


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you run `eslint` on the code and resolved any errors?
- [x] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

I have this suggestion to print the extension that is initializing i18next.
I manually tested the code with `npm run build` and `npm run start`.

### Benefits

Instead of printing:
```
Initializing i18next for extensions...
Initializing i18next for extensions...
Initializing i18next for extensions...
Initializing i18next for extensions...
```
this is printed:
```
Initializing i18next for extension customlevel...
Initializing i18next for extension ocw...
Initializing i18next for extension smm2...
Initializing i18next for extension customcode...
```

### Potential drawbacks

Not that I know of.
