### PR TITLE
Fix version warning when using Docker develop tags

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -9,6 +9,15 @@ declare global {
 }
 
 export function buildVersion(): string | null {
+  if (
+    (process.env.DOCKER_TAG == "this" || process.env.DOCKER_TAG == "develop") &&
+    process.env.SOURCE_COMMIT
+  ) {
+    // If we're running in Docker on the develop branch,
+    // this needs to be the develop-abcdef version number.
+    // Otherwise users will always see an error.
+    return version();
+  }
   if (globalThis.__build_version != null && globalThis.__build_version != "") {
     return globalThis.__build_version;
   }


### PR DESCRIPTION
The version check doesn't work right with Docker; since the user isn't building the bot, we should probably skip it anyway, so that's what this does. Without this change, the `develop` tag will always print an error (e.g. `Warning: Running a different version of the queue (version 2.0.0-beta.3 instead of develop-aa79dd0e)`).