### PR TITLE
Random chance weight is only increased whenever the stream is online

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ## Bug fixes
 
 - You no longer get the message `your level has been removed from the queue` when you use `!leave` and do not have a level in the queue.
+- Random chance weight is only increased whenever the stream is online.
 
 ## Other changes
 

--- a/locales/en/fluid-queue.json
+++ b/locales/en/fluid-queue.json
@@ -98,5 +98,7 @@
   "queueCleared": "The queue has been cleared!",
   "userLurk": "See you later, {{sender.displayName}}! Your level will not be played until you use the !back command.",
   "noOrder": "No order has been specified.",
-  "orderList": "Next level order: {{order, list}}"
+  "orderList": "Next level order: {{order, list}}",
+  "streamIsOnline": "[{{time}}] Stream is online!",
+  "streamIsOffline": "[{{time}}] Stream is offline!"
 }

--- a/src/twitch-api.ts
+++ b/src/twitch-api.ts
@@ -106,6 +106,7 @@ class TwitchApi {
       "chat",
       "user-by-name",
       "chatters",
+      "stream-online",
     ]);
     // create the api client
     this.#apiClient = new ApiClient({
@@ -208,6 +209,17 @@ class TwitchApi {
   async getUsers(userNames: string[]): Promise<User[]> {
     return this.apiClient.asIntent(["user-by-name"], (ctx) => {
       return ctx.users.getUsersByNames(userNames);
+    });
+  }
+
+  async isStreamOnline(): Promise<boolean> {
+    return await this.apiClient.asIntent(["stream-online"], async (ctx) => {
+      if (this.#broadcasterUser == null) {
+        throw new Error("#broadcasterUser null");
+      }
+      return (
+        (await ctx.streams.getStreamByUserId(this.#broadcasterUser)) != null
+      );
     });
   }
 }

--- a/tests/simulation.ts
+++ b/tests/simulation.ts
@@ -263,6 +263,8 @@ export async function mockTwitchApi(): Promise<typeof twitchApiModule> {
             displayName: `\${user(${JSON.stringify(user)}).displayName}`,
           }));
       });
+
+      isStreamOnline = jest.fn(async () => true);
     }
     return {
       TwitchApi,


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you run `eslint` on the code and resolved any errors?
- [x] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

The queue checks if the stream is online before adding weight to online users.
Note that this currently uses an ISO timestamp in chat for the messages when the stream goes online or offline, so it's easier to debug when looking at the logs.

### Benefits

You can keep the bot running without creating an unfair advantage of anyone staying connected to chat and gaining weight while the stream is offline.

### Potential drawbacks

An API call per minute is made to check the stream status.
We could probably cache the value for something like 10min or so, but I think doing it like this is okay and more accurate.
