### PR TITLE
Fix tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "zod": "^3.21.4"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --config ./tests/jest.config.json --verbose",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config ./tests/jest.config.json --verbose",
     "start": "node --enable-source-maps ./build/index.js",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "build": "node --loader @swc-node/register/esm ./build.ts",

--- a/tests/data-conversion/data-conversion.test.ts
+++ b/tests/data-conversion/data-conversion.test.ts
@@ -600,9 +600,12 @@ test("test-renamed-or-deleted", async () => {
   const index = await simRequireIndex(volume, undefined, 1683058095000);
   const mockFs = index.fs;
   // should load without errors and no exception was thrown
-  const fileName = `data/lost-levels-${
-    new Date().toISOString().replaceAll(":", "").split(".")[0]
-  }Z.json`;
+  const fileName = path.join(
+    "data",
+    `lost-levels-${
+      new Date().toISOString().replaceAll(":", "").split(".")[0]
+    }Z.json`
+  );
   expect(consoleWarnMock).toHaveBeenCalledTimes(4);
   expect(consoleWarnMock).toHaveBeenCalledWith(
     "4 users in your queue could not be found!"


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you run `eslint` on the code and resolved any errors?
- [x] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

This PR fixes #78. Jest does not run correctly, because the `NODE_OPTIONS=--experimental-vm-modules` environment variable can not be set in `package.json` for running tests under Windows.
The solution is to start `jest` through `node` and pass the `--experimental-vm-modules` as argument instead of an environment variable.

This also fixes one test (`test-renamed-or-deleted`) where the path was assumed to contain `/`, but under windows the queue will print `\` in the logs.

I tested the tests on Windows 10 Version `22H2 (OS Build 19045.2965)` using node version `v18.6.0` (our minimum required version), and npm version `8.12.1` with:
```cmd
npm i
npm test
```
Result:
```
Test Suites: 6 passed, 6 total
Tests:       91 passed, 91 total
Snapshots:   0 total
Time:        16.757 s
Ran all test suites.
```

### Benefits

Tests run under Windows as well as Linux.

### Potential drawbacks

How to start `jest` through `node` might change in a future version, however the [ECMAScript Modules guide](https://jestjs.io/docs/ecmascript-modules) says how to start `jest` through `node` correctly.
