### PR TITLE
Update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,7 +1,7 @@
 ### Checklist
 
 - [ ] Have you followed the guidelines in our Contributing document?
-- [ ] Have you run `eslint` on the code and resolved any errors?
+- [ ] Have you run `npm run check` on the code and resolved any errors?
 - [ ] Have you run `npm test` and all tests are passing?
 - [ ] Have you added new tests for any new functions created?
 - [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [ ] Have you run `eslint` on the code and resolved any errors?
- [ ] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

Changes the requirement to run `eslint` to run `npm run check`.

Also moves the template from `PULL_REQUEST_TEMPLATE.md` to `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md` as one of the options described in [creating a pull request template for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).
This way we hide the pull request template a little bit more, and makes it analogue to how issue templates are stored.

### Benefits

Easier to understand that instead of running `npx eslint .`, `npm run check` should be run (the full command is present in the template).
This also catches TypeScript errors now and not just `eslint` errors.

### Potential drawbacks

The checks take longer to run.
