### PR TITLE
Use broadcaster token for mods and subs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - The minimum node version is now `18.6.0` and the docker image is now build with node version `20`.
 - `!clear` no longer clears all levels, instead you have to use `!clear all` to clear all levels; or instead set the `"clear"` setting in `settings/settings.yml` to `"all"` and then `!clear` clears all levels again.
 - Subscribers and moderators are now monitored through eventsub and with a check when the stream comes online. This requires new token scopes, and a warning will be printed during startup (and this functionality disabled) if the scopes are missing.
+  - This is now implemented with a separate (optional) broadcaster token.
+  - As a result of this, the bot no longer has to be mod, so long as a broadcaster token is provided with the `moderator:read:chatters` scope.
 
 ## New features
 

--- a/locales/en/fluid-queue.json
+++ b/locales/en/fluid-queue.json
@@ -111,7 +111,7 @@
   "orderList": "Next level order: {{order, list}}",
   "streamIsOnline": "Stream is online!",
   "streamIsOffline": "Stream is offline!",
-  "requiredScopeError": "Missing required scope in token. Please generate a new token providing all required scopes.",
-  "subscribersScopeMissing": "Missing the channel:read:subscriptions scope in token. Subscriber multipliers won't apply until the subscriber sends a chat message.",
-  "moderatorsScopeMissing": "Missing the moderation:read scope in token. !modnext (etc) will not work for mods until they speak in chat."
+  "requiredScopeError": "Missing required scope in bot token. Please generate a new token providing all required scopes.",
+  "subscribersScopeMissing": "Missing a broadcaster token, or the provided broadcaster token is missing the channel:read:subscriptions scope. Subscriber multipliers won't apply until the subscriber sends a chat message.",
+  "moderatorsScopeMissing": "Missing a broadcaster token, or the provided broadcaster token is missing the moderation:read scope. !modnext (etc) will not work for mods until they speak in chat."
 }

--- a/src/twitch-api.ts
+++ b/src/twitch-api.ts
@@ -196,6 +196,22 @@ class TwitchApi {
         tokenData = InitialTokenScheme.parse(
           JSON.parse(fs.readFileSync(broadcasterTokensFileName, "utf-8"))
         );
+      } catch (err) {
+        if (
+          typeof err === "object" &&
+          err != null &&
+          "code" in err &&
+          err.code === "ENOENT"
+        ) {
+          // There's no provided tokens for the broadcaster
+          this.#broadcasterTokenScopes = [];
+          this.#authProvider.addIntentsToUser(this.#botUserId, ["chatters"]);
+        } else {
+          throw err;
+        }
+      }
+
+      if (tokenData) {
         const id = await this.#authProvider.addUserForToken(tokenData, [
           "subscribers-by-broadcaster",
           "moderators-by-broadcaster",
@@ -213,18 +229,6 @@ class TwitchApi {
           this.#authProvider.addIntentsToUser(id, ["chatters"]);
         } else {
           this.#authProvider.addIntentsToUser(this.#botUserId, ["chatters"]);
-        }
-      } catch (err) {
-        if (
-          typeof err === "object" &&
-          err != null &&
-          "code" in err &&
-          err.code === "ENOENT"
-        ) {
-          this.#broadcasterTokenScopes = [];
-          this.#authProvider.addIntentsToUser(this.#botUserId, ["chatters"]);
-        } else {
-          throw err;
         }
       }
     }

--- a/src/twitch-api.ts
+++ b/src/twitch-api.ts
@@ -20,6 +20,7 @@ import { z } from "zod";
 import { warn } from "./chalk-print.js";
 
 const tokensFileName = "./settings/tokens.json";
+const broadcasterTokensFileName = "./settings/tokens.broadcaster.json";
 
 const InitialTokenScheme = z
   .object({
@@ -37,7 +38,8 @@ class TwitchApi {
   #apiClient: ApiClient | null = null;
   #broadcasterUser: HelixUser | null = null;
   #chattersCache: SingleValueCache<User[]>;
-  #tokenScopes: string[] = [];
+  #botTokenScopes: string[] = [];
+  #broadcasterTokenScopes: string[] = [];
   #esListener: EventSubWsListener | null = null;
 
   constructor() {
@@ -78,8 +80,12 @@ class TwitchApi {
     return this.#botUserId;
   }
 
-  get tokenScopes(): string[] {
-    return this.#tokenScopes;
+  get botTokenScopes(): string[] {
+    return this.#botTokenScopes;
+  }
+
+  get broadcasterTokenScopes(): string[] {
+    return this.#broadcasterTokenScopes;
   }
 
   /**
@@ -120,16 +126,28 @@ class TwitchApi {
         `Invalid ${tokensFileName} file: refreshToken not found.`
       );
     }
+
     // create the refreshing provider
     this.#authProvider = new RefreshingAuthProvider({
       clientId: settings.clientId,
       clientSecret: settings.clientSecret,
-      onRefresh: (userId, newTokenData) =>
-        writeFileAtomicSync(
-          tokensFileName,
-          JSON.stringify(newTokenData, null, 4),
-          { encoding: "utf-8" }
-        ),
+      onRefresh: (userId, newTokenData) => {
+        let fileName;
+        if (this.#botUserId == null || this.#botUserId == userId) {
+          // this has to be the bot token, since the id is not known yet or matches
+          fileName = tokensFileName;
+        } else if (this.#broadcasterUser?.id == userId) {
+          // note that `this.#broadcasterUser` is set before the token is even added to the provider
+          fileName = broadcasterTokensFileName;
+        } else {
+          throw new Error(
+            `Unknown token with user id ${userId}. Does the channel setting differ from the token user?`
+          );
+        }
+        writeFileAtomicSync(fileName, JSON.stringify(newTokenData, null, 4), {
+          encoding: "utf-8",
+        });
+      },
     });
     // register refresh and access token of the bot and get the user id of the bot
     // this token is used for both chat as well as api calls
@@ -137,10 +155,7 @@ class TwitchApi {
       "chat",
       "user-by-name",
       "user-by-id",
-      "chatters",
       "stream-online",
-      "subscribers-by-broadcaster",
-      "moderators-by-broadcaster",
     ]);
     // create the api client
     this.#apiClient = new ApiClient({
@@ -163,30 +178,80 @@ class TwitchApi {
     }
 
     // get the scopes
-    this.#tokenScopes = this.#authProvider.getCurrentScopesForUser(
+    this.#botTokenScopes = this.#authProvider.getCurrentScopesForUser(
       this.#botUserId
     );
+    if (this.#broadcasterUser.id == this.#botUserId) {
+      // if the bot is the broadcaster add intents to bot/broadcaster account
+      this.#authProvider.addIntentsToUser(this.#botUserId, [
+        "subscribers-by-broadcaster",
+        "moderators-by-broadcaster",
+        "chatters",
+      ]);
+      this.#broadcasterTokenScopes = this.#botTokenScopes;
+    } else {
+      // look for a broadcaster tokens file
+      let tokenData;
+      try {
+        tokenData = InitialTokenScheme.parse(
+          JSON.parse(fs.readFileSync(broadcasterTokensFileName, "utf-8"))
+        );
+        const id = await this.#authProvider.addUserForToken(tokenData, [
+          "subscribers-by-broadcaster",
+          "moderators-by-broadcaster",
+        ]);
+        if (id != this.#broadcasterUser.id) {
+          throw new Error(
+            `Broadcaster id ${
+              this.#broadcasterUser.id
+            } does not match token user id ${id}`
+          );
+        }
+        this.#broadcasterTokenScopes =
+          this.#authProvider.getCurrentScopesForUser(id);
+        if (this.#broadcasterTokenScopes.includes("moderator:read:chatters")) {
+          this.#authProvider.addIntentsToUser(id, ["chatters"]);
+        } else {
+          this.#authProvider.addIntentsToUser(this.#botUserId, ["chatters"]);
+        }
+      } catch (err) {
+        if (
+          typeof err === "object" &&
+          err != null &&
+          "code" in err &&
+          err.code === "ENOENT"
+        ) {
+          this.#broadcasterTokenScopes = [];
+          this.#authProvider.addIntentsToUser(this.#botUserId, ["chatters"]);
+        } else {
+          throw err;
+        }
+      }
+    }
     // set up the eventsub listener
     const apiClient = this.#apiClient;
     this.#esListener = new EventSubWsListener({ apiClient });
 
     if (
-      !this.#tokenScopes.includes("chat:edit") ||
-      !this.#tokenScopes.includes("chat:read") ||
-      !this.#tokenScopes.includes("moderator:read:chatters")
+      !this.#botTokenScopes.includes("chat:edit") ||
+      !this.#botTokenScopes.includes("chat:read") ||
+      !(
+        this.#broadcasterTokenScopes.includes("moderator:read:chatters") ||
+        this.#botTokenScopes.includes("moderator:read:chatters")
+      )
     ) {
       const err = i18next.t("requiredScopeError");
       throw new Error(err);
     }
-    if (!this.#tokenScopes.includes("channel:read:subscriptions")) {
+    if (!this.#broadcasterTokenScopes.includes("channel:read:subscriptions")) {
       warn(i18next.t("subscribersScopeMissing"));
     }
-    if (!this.#tokenScopes.includes("moderation:read")) {
+    if (!this.#broadcasterTokenScopes.includes("moderation:read")) {
       warn(i18next.t("moderatorsScopeMissing"));
     }
 
     let startListener = false;
-    if (this.#tokenScopes.includes("channel:read:subscriptions")) {
+    if (this.#broadcasterTokenScopes.includes("channel:read:subscriptions")) {
       // set up the eventsub listeners for subs
       this.#esListener.onChannelSubscription(
         this.#broadcasterUser.id,
@@ -198,7 +263,7 @@ class TwitchApi {
       );
       startListener = true;
     }
-    if (this.#tokenScopes.includes("moderation:read")) {
+    if (this.#broadcasterTokenScopes.includes("moderation:read")) {
       // Set up the eventsub listeners for mods
       this.#esListener.onChannelModeratorAdd(
         this.#broadcasterUser.id,

--- a/src/twitch.ts
+++ b/src/twitch.ts
@@ -108,7 +108,9 @@ const twitch = {
    * Updates the list of subscribers in chat, assuming the API token has permission to.
    */
   async updateModsAndSubscribers() {
-    if (twitchApi.tokenScopes.includes("channel:read:subscriptions")) {
+    if (
+      twitchApi.broadcasterTokenScopes.includes("channel:read:subscriptions")
+    ) {
       for (const subscriber of await twitchApi.getSubscribers()) {
         if (!subscribers.has(subscriber.id)) {
           subscribers.set(subscriber.id, subscriber);
@@ -116,7 +118,7 @@ const twitch = {
       }
     }
 
-    if (twitchApi.tokenScopes.includes("moderation:read")) {
+    if (twitchApi.broadcasterTokenScopes.includes("moderation:read")) {
       for (const mod of await twitchApi.getModerators()) {
         if (!mods.has(mod.id)) {
           mods.set(mod.id, mod);

--- a/tests/simulation.ts
+++ b/tests/simulation.ts
@@ -344,7 +344,7 @@ export async function mockTwitchApi(): Promise<typeof twitchApiModule> {
       );
 
       isStreamOnline = jest.fn(() => Promise.resolve(true));
-      botTokenScopes = ["char:read", "chat:edit", "moderator:read:chatters"];
+      botTokenScopes = ["chat:read", "chat:edit", "moderator:read:chatters"];
       broadcasterTokenScopes = [
         "channel:read:subscriptions",
         "moderation:read",

--- a/tests/simulation.ts
+++ b/tests/simulation.ts
@@ -344,10 +344,8 @@ export async function mockTwitchApi(): Promise<typeof twitchApiModule> {
       );
 
       isStreamOnline = jest.fn(() => Promise.resolve(true));
-      tokenScopes = [
-        "char:read",
-        "chat:edit",
-        "moderator:read:chatters",
+      botTokenScopes = ["char:read", "chat:edit", "moderator:read:chatters"];
+      broadcasterTokenScopes = [
         "channel:read:subscriptions",
         "moderation:read",
       ];


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you run `eslint` on the code and resolved any errors?
- [x] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

Getting the subscribers and moderators from the API requires having a broadcaster token.
When the bot is also the broadcaster it just works, but this PR introduces a way to create a `settings/tokens.broadcaster.json` file that contains a separate token for the broadcaster.

### Benefits

One can fetch the subscribers/moderators using a different bot account as the broadcaster.

### Potential drawbacks

Code gets more complicated and it is difficult to test all cases.
