### PR TITLE
Setting test timeout to 10s

### DIFF
--- a/tests/chat-logs/chat-logs.test.ts
+++ b/tests/chat-logs/chat-logs.test.ts
@@ -400,5 +400,12 @@ for (const file of testFiles) {
     ".",
     path.resolve(path.dirname(fileURLToPath(import.meta.url)), `chat/${file}`)
   );
-  test(fileName, chatLogTest(fileName));
+  test(
+    fileName,
+    () => {
+      jest.setTimeout(10_000); // <- this might not work
+      chatLogTest(fileName);
+    },
+    10_000 // <- setting timeout here as well
+  );
 }

--- a/tests/jest.config.json
+++ b/tests/jest.config.json
@@ -11,5 +11,6 @@
     "^.+\\.(t|j)sx?$": "@swc/jest"
   },
   "rootDir": "..",
-  "roots": ["<rootDir>/src/", "<rootDir>/tests/"]
+  "roots": ["<rootDir>/src/", "<rootDir>/tests/"],
+  "testTimeout": 10000
 }


### PR DESCRIPTION
The test timeout is now 10 seconds.
It is difficult to test this and this could also have a different effect on different operating systems as well.
See https://github.com/jestjs/jest/issues/11607.