### PR TITLE
Allow starting the queue with SWC

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "build": "node --loader @swc-node/register/esm ./build.ts",
     "clean": "rimraf build/",
-    "check": "npx tsc --noemit && eslint .",
+    "check": "tsc --noemit && eslint .",
     "dist-clean": "rimraf build/ dist/",
-    "dist-build": "npm run check && npm run test && npm run build && node --loader @swc-node/register/esm ./dist.ts"
+    "dist-build": "npm run check && npm run test && npm run build && node --loader @swc-node/register/esm ./dist.ts",
+    "fmt": "prettier --write ."
   },
   "devDependencies": {
     "@babel/code-frame": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config ./tests/jest.config.json --verbose",
     "start": "node --enable-source-maps ./build/index.js",
+    "start:swc": "node --loader @swc-node/register/esm ./src/index.ts",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "build": "node --loader @swc-node/register/esm ./build.ts",
     "clean": "rimraf build/",

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -34,7 +34,7 @@ import {
   QueueEntryApi,
 } from "./extensions-api/resolvers.js";
 import { BroadcastOnce, SendOnce } from "./sync.js";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import i18next from "i18next";
 import { log, warn, error } from "./chalk-print.js";
 
@@ -127,14 +127,12 @@ const loadExtensionModules = async (
 
   const importModules: Promise<{ name: string; module: object }>[] =
     moduleFiles.map(async ({ name, fileName }) => {
-      let prefix = "";
-      if (process.platform === "win32") {
-        prefix = "file://";
-      }
-      const importName = prefix + path.join(directory, fileName);
-      const module: unknown = await import(importName);
+      const importUrl = pathToFileURL(
+        path.join(directory, fileName)
+      ).toString();
+      const module: unknown = await import(importUrl);
       if (typeof module !== "object" || module == null) {
-        throw new Error(`Module ${importName} does not export an object!`);
+        throw new Error(`Module ${importUrl} does not export an object!`);
       }
       return { name, module };
     });

--- a/src/extensions/customcode.ts
+++ b/src/extensions/customcode.ts
@@ -7,7 +7,7 @@ import { Result } from "../extensions-api/helpers.js";
 import { Chatter } from "../extensions-api/command.js";
 import i18next from "i18next";
 
-await (await import("./helpers/i18n.js")).init("customcode");
+await (await import("./helpers/i18n.js")).init("customcode", import.meta.url);
 
 class CustomCodes {
   map: Map<string, { customCode: string; entry: Entry }> = new Map<

--- a/src/extensions/customlevel.ts
+++ b/src/extensions/customlevel.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import i18next from "i18next";
 import { log } from "../chalk-print.js";
 
-await (await import("./helpers/i18n.js")).init("customlevel");
+await (await import("./helpers/i18n.js")).init("customlevel", import.meta.url);
 
 const QUEUE_NAMESPACE = "1e511052-e714-49bb-8564-b60915cf7279"; // this is the namespace for *known* level types for the queue (Version 4 UUID)
 const ROMHACK_UUID = uuidv5("ROMhack", QUEUE_NAMESPACE);

--- a/src/extensions/helpers/i18n.ts
+++ b/src/extensions/helpers/i18n.ts
@@ -5,29 +5,33 @@ import { fileURLToPath } from "url";
 import { readdirSync, lstatSync } from "fs";
 import { log } from "../../chalk-print.js";
 
-export async function init(extension: string) {
-  if (process && process.env && process.env.NODE_ENV != "test") {
+/**
+ * @param extension The name of the extension.
+ * @param url The url of the extension used to locate the locales folder.
+ */
+export async function init(extension: string, url?: string) {
+  if (!i18next.use(FsBackend).isInitialized) {
+    // Only initialize i18next if it has not been initialized yet.
+    // This is the case for extensions loaded by the esbuild code.
     const { options } = await import("../../i18next-options.js");
-
-    // Tests are hecking weird, and don't need this, and break because of this
-    // This feels like a hack but it works
-    const dirname = pathDirname(fileURLToPath(import.meta.url));
+    const localesPath = join(
+      pathDirname(fileURLToPath(url ?? import.meta.url)),
+      "../../locales"
+    );
 
     log(`Initializing i18next for extension ${extension}...`);
     await i18next.use(FsBackend).init<FsBackendOptions>({
       ...options,
       backend: {
         ...options.backend,
-        loadPath: join(dirname, "../../locales/{{lng}}/{{ns}}.json"),
-        addPath: join(dirname, "../../locales/{{lng}}/{{ns}}.missing.json"),
+        loadPath: join(localesPath, "{{lng}}/{{ns}}.json"),
+        addPath: join(localesPath, "{{lng}}/{{ns}}.missing.json"),
       },
-      preload: readdirSync(join(dirname, "../../locales")).filter(
-        (fileName) => {
-          const joinedPath = join(join(dirname, "../../locales"), fileName);
-          const isDirectory = lstatSync(joinedPath).isDirectory();
-          return isDirectory;
-        }
-      ),
+      preload: readdirSync(localesPath).filter((fileName) => {
+        const joinedPath = join(localesPath, fileName);
+        const isDirectory = lstatSync(joinedPath).isDirectory();
+        return isDirectory;
+      }),
     });
   }
   await i18next.loadNamespaces(extension);

--- a/src/extensions/ocw.ts
+++ b/src/extensions/ocw.ts
@@ -7,7 +7,7 @@ import {
 } from "./helpers/codeparsing.js";
 import i18next from "i18next";
 
-await (await import("./helpers/i18n.js")).init("ocw");
+await (await import("./helpers/i18n.js")).init("ocw", import.meta.url);
 
 // Need a slightly different regex because we don't know what OCW IDs will end with
 // If anyone figures that out, we can update this, but it would still be different

--- a/src/extensions/smm2.ts
+++ b/src/extensions/smm2.ts
@@ -7,7 +7,7 @@ import {
 } from "./helpers/codeparsing.js";
 import i18next from "i18next";
 
-await (await import("./helpers/i18n.js")).init("smm2");
+await (await import("./helpers/i18n.js")).init("smm2", import.meta.url);
 
 const delim = "[-. ]?";
 const code = "[A-Ha-hJ-Nj-nP-Yp-y0-9]{3}";


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you run `eslint` on the code and resolved any errors?
- [x] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

Changes to allow the code to run with `node --loader @swc-node/register/esm ./src/index.ts` which is an easier way of quickly testing changes during development than using `npm run build` and `npm run start`.

Added scripts:
- `fmt` to format the code using prettier
- `start:swc` to start the queue using SWC

SWC requires `file://` links for extensions imports (not just for windows), so I just changed the import code to always use file URLs by using the `pathToFileURL` function.

Loading i18next in extensions now use `i18next.use(FsBackend).isInitialized` to check if i18next was loaded yet instead of checking if the code is running in the test environment.

### Benefits

Easier because one can not forget to run `npm run build`.
It may or may not be faster to use swc than building the code (I have not tested this).
Source code has some general improvements.

### Potential drawbacks

Someone who is not using this for development reason might start the queue using SWC instead of starting the queue the recommended way.
