### PR TITLE
Resolve sources from tests in a better way

### DIFF
--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,6 +1,6 @@
 import { jest } from "@jest/globals";
-import { ConcurrentLoader, SingleValueCache } from "../src/cache.js";
-import { BroadcastOnce } from "../src/sync.js";
+import { ConcurrentLoader, SingleValueCache } from "fluid-queue/cache.js";
+import { BroadcastOnce } from "fluid-queue/sync.js";
 import { Duration } from "@js-joda/core";
 import { expectErrorMessage } from "./simulation.js";
 

--- a/tests/jest.config.json
+++ b/tests/jest.config.json
@@ -3,8 +3,8 @@
   "testEnvironment": "node",
   "modulePathIgnorePatterns": ["<rootDir>/build"],
   "moduleNameMapper": {
-    "^\\.{2}/src/(.*)\\.js$": "<rootDir>/src/$1",
-    "^(\\.{1,2}/.*)\\.js$": "$1"
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+    "^fluid-queue/(.*)\\.js$": "<rootDir>/src/$1"
   },
   "extensionsToTreatAsEsm": [".ts"],
   "transform": {

--- a/tests/persistence.test.ts
+++ b/tests/persistence.test.ts
@@ -6,7 +6,7 @@ import {
   expectErrorMessage,
   mockTwitchApi,
 } from "./simulation.js";
-import { User } from "../src/extensions-api/queue-entry.js";
+import { User } from "fluid-queue/extensions-api/queue-entry.js";
 import { Volume, createFsFromVolume } from "memfs";
 import path from "path";
 
@@ -53,7 +53,7 @@ async function runHooks(hooks: (() => Promise<void> | void)[]): Promise<void> {
 
 test("UpgradeEngine:load", async () => {
   await setupMocks();
-  const { UpgradeEngine } = await import("../src/persistence.js");
+  const { UpgradeEngine } = await import("fluid-queue/persistence.js");
   const engine = UpgradeEngine.from<string>(() => "loaded");
   const result = await engine.load(() => "created");
   expect(result.data).toEqual("loaded");
@@ -64,7 +64,7 @@ test("UpgradeEngine:load", async () => {
 
 test("UpgradeEngine:create", async () => {
   await setupMocks();
-  const { UpgradeEngine } = await import("../src/persistence.js");
+  const { UpgradeEngine } = await import("fluid-queue/persistence.js");
   const engine = UpgradeEngine.from<string>(() => null);
   const result = await engine.load(() => "created");
   expect(result.data).toEqual("created");
@@ -76,7 +76,7 @@ test("UpgradeEngine:create", async () => {
 test("UpgradeEngine:upgrade", async () => {
   await setupMocks();
   let upgradeHookCalled = false;
-  const { UpgradeEngine } = await import("../src/persistence.js");
+  const { UpgradeEngine } = await import("fluid-queue/persistence.js");
   const engine = UpgradeEngine.from<string>(() => "loaded").upgrade(
     (value) => ({
       data: `upgraded(${value})`,
@@ -100,7 +100,7 @@ test("UpgradeEngine:upgrade", async () => {
 
 test("UpgradeEngine:create-with-upgrade", async () => {
   await setupMocks();
-  const { UpgradeEngine } = await import("../src/persistence.js");
+  const { UpgradeEngine } = await import("fluid-queue/persistence.js");
   const engine = UpgradeEngine.from<string>(() => null).upgrade(
     (value) => ({
       data: `upgraded(${value})`,
@@ -121,7 +121,7 @@ test("UpgradeEngine:create-with-upgrade", async () => {
 
 test("UpgradeEngine:load-with-upgrade", async () => {
   await setupMocks();
-  const { UpgradeEngine } = await import("../src/persistence.js");
+  const { UpgradeEngine } = await import("fluid-queue/persistence.js");
   const engine = UpgradeEngine.from<string>(() => "loaded").upgrade(
     (value) => ({
       data: `upgraded(${value})`,
@@ -143,7 +143,7 @@ test("UpgradeEngine:load-with-upgrade", async () => {
 test("UpgradeEngine:upgrade-twice", async () => {
   const hookCalls: string[] = [];
   await setupMocks();
-  const { UpgradeEngine } = await import("../src/persistence.js");
+  const { UpgradeEngine } = await import("fluid-queue/persistence.js");
   const engine = UpgradeEngine.from<string>(() => "loaded")
     .upgrade(
       (value) => ({
@@ -202,7 +202,7 @@ class SaveAndVerify<T> {
 
 test("loadResultActions:data", async () => {
   await setupMocks();
-  const { loadResultActions } = await import("../src/persistence.js");
+  const { loadResultActions } = await import("fluid-queue/persistence.js");
   const { save, verify } = SaveAndVerify.create<string>();
   const result = await loadResultActions(
     {
@@ -220,7 +220,7 @@ test("loadResultActions:data", async () => {
 
 test("loadResultActions:save-and-verify", async () => {
   await setupMocks();
-  const { loadResultActions } = await import("../src/persistence.js");
+  const { loadResultActions } = await import("fluid-queue/persistence.js");
   const { save, verify } = SaveAndVerify.create<string>();
   const result = await loadResultActions(
     {
@@ -240,7 +240,7 @@ test("loadResultActions:save-and-verify", async () => {
 test("loadResultActions:save-and-verify-hooks-abort-null", async () => {
   const hookCalls: number[] = [];
   await setupMocks();
-  const { loadResultActions } = await import("../src/persistence.js");
+  const { loadResultActions } = await import("fluid-queue/persistence.js");
   const { save, verify } = SaveAndVerify.create<string>();
   verify.mockReturnValue(null);
   const promise = loadResultActions(
@@ -268,7 +268,7 @@ test("loadResultActions:save-and-verify-hooks-abort-null", async () => {
 test("loadResultActions:save-and-verify-hooks-abort-throws", async () => {
   const hookCalls: number[] = [];
   await setupMocks();
-  const { loadResultActions } = await import("../src/persistence.js");
+  const { loadResultActions } = await import("fluid-queue/persistence.js");
   const { save, verify } = SaveAndVerify.create<string>();
   verify.mockImplementation(() => {
     throw new Error("Loading failed!");
@@ -296,7 +296,7 @@ test("loadResultActions:save-and-verify-hooks-abort-throws", async () => {
 test("loadResultActions:save-and-verify-hooks-abort-save-off", async () => {
   const hookCalls: number[] = [];
   await setupMocks();
-  const { loadResultActions } = await import("../src/persistence.js");
+  const { loadResultActions } = await import("fluid-queue/persistence.js");
   const { save, verify } = SaveAndVerify.create<string>();
   const promise = loadResultActions(
     {
@@ -324,7 +324,7 @@ test("loadResultActions:save-and-verify-save-off", async () => {
   const consoleWarnMock = jest.spyOn(global.console, "warn");
   // this works because there are no hooks
   await setupMocks();
-  const { loadResultActions } = await import("../src/persistence.js");
+  const { loadResultActions } = await import("fluid-queue/persistence.js");
   const { save, verify } = SaveAndVerify.create<string>();
   const result = await loadResultActions(
     {
@@ -348,7 +348,7 @@ test("loadResultActions:save-and-verify-save-off", async () => {
 
 test("VersionedFile:no-file", async () => {
   await setupMocks();
-  const { VersionedFile } = await import("../src/persistence.js");
+  const { VersionedFile } = await import("fluid-queue/persistence.js");
   const versionedFile = VersionedFile.from(1, (object) => {
     return `loaded(${JSON.stringify(object)})`;
   });
@@ -365,7 +365,7 @@ test("VersionedFile:no-file", async () => {
 
 test("VersionedFile:version-one", async () => {
   const fs = await setupMocks();
-  const { VersionedFile } = await import("../src/persistence.js");
+  const { VersionedFile } = await import("fluid-queue/persistence.js");
   const versionedFile = VersionedFile.from(1, (object) => {
     return `loaded(${JSON.stringify(object)})`;
   });
@@ -395,7 +395,7 @@ test("VersionedFile:version-one", async () => {
 test("VersionedFile:version-three", async () => {
   const hookCalls: number[] = [];
   const fs = await setupMocks();
-  const { VersionedFile } = await import("../src/persistence.js");
+  const { VersionedFile } = await import("fluid-queue/persistence.js");
   const versionedFile = VersionedFile.from(1, (object) => {
     return `loaded(${JSON.stringify(object)})`;
   })
@@ -447,7 +447,7 @@ test("VersionedFile:version-three", async () => {
 test("VersionedFile:version-two-upgrade-to-three", async () => {
   let hookCalls: number[] = [];
   const fs = await setupMocks();
-  const { VersionedFile } = await import("../src/persistence.js");
+  const { VersionedFile } = await import("fluid-queue/persistence.js");
   const versionedFile = VersionedFile.from(1, (object) => {
     return `loaded(${JSON.stringify(object)})`;
   })
@@ -506,7 +506,7 @@ test("VersionedFile:version-two-upgrade-to-three", async () => {
 test("VersionedFile:version-one-upgrade-to-three", async () => {
   let hookCalls: number[] = [];
   const fs = await setupMocks();
-  const { VersionedFile } = await import("../src/persistence.js");
+  const { VersionedFile } = await import("fluid-queue/persistence.js");
   const versionedFile = VersionedFile.from(1, (object) => {
     return `loaded(${JSON.stringify(object)})`;
   })
@@ -565,7 +565,7 @@ test("VersionedFile:version-one-upgrade-to-three", async () => {
 test("VersionedFile:version-too-big", async () => {
   const hookCalls: number[] = [];
   const fs = await setupMocks();
-  const { VersionedFile } = await import("../src/persistence.js");
+  const { VersionedFile } = await import("fluid-queue/persistence.js");
   const versionedFile = VersionedFile.from(1, (object) => {
     return `loaded(${JSON.stringify(object)})`;
   })
@@ -608,7 +608,7 @@ test("VersionedFile:version-too-big", async () => {
 test("VersionedFile:version-too-small", async () => {
   const hookCalls: number[] = [];
   const fs = await setupMocks();
-  const { VersionedFile } = await import("../src/persistence.js");
+  const { VersionedFile } = await import("fluid-queue/persistence.js");
   const versionedFile = VersionedFile.from(1, (object) => {
     return `loaded(${JSON.stringify(object)})`;
   })

--- a/tests/simulation.ts
+++ b/tests/simulation.ts
@@ -5,18 +5,21 @@ import { FunctionLike } from "jest-mock";
 import { Volume, createFsFromVolume } from "memfs";
 import path from "path";
 import fs from "fs";
-import * as twitchApiModule from "../src/twitch-api.js";
+import * as twitchApiModule from "fluid-queue/twitch-api.js";
 import {
   SetIntervalAsyncHandler,
   SetIntervalAsyncTimer,
 } from "set-interval-async";
-import { Settings } from "../src/settings-type.js";
-import { Chatter, Responder } from "../src/extensions-api/command.js";
-import { Chatbot, helper } from "../src/chatbot.js";
+import { Settings } from "fluid-queue/settings-type.js";
+import { Chatter, Responder } from "fluid-queue/extensions-api/command.js";
+import { Chatbot, helper } from "fluid-queue/chatbot.js";
 import { z } from "zod";
-import { QueueSubmitter, User } from "../src/extensions-api/queue-entry.js";
-import { Queue } from "../src/queue.js";
-import { Twitch } from "../src/twitch.js";
+import {
+  QueueSubmitter,
+  User,
+} from "fluid-queue/extensions-api/queue-entry.js";
+import { Queue } from "fluid-queue/queue.js";
+import { Twitch } from "fluid-queue/twitch.js";
 import * as timers from "timers";
 import { fileURLToPath } from "url";
 import YAML from "yaml";
@@ -56,7 +59,7 @@ let clearAllTimersIntern: (() => Promise<void>) | null = null;
 const mockModules = async () => {
   // mocks
   const twitchApi = (await mockTwitchApi()).twitchApi;
-  jest.unstable_mockModule("../src/chatbot.js", () => {
+  jest.unstable_mockModule("fluid-queue/chatbot.js", () => {
     const chatbot_helper = jest.fn((): Chatbot => {
       return {
         client: null, // do not mock client, since it is not used outside
@@ -261,7 +264,7 @@ function asMock<T, K extends keyof T>(
 }
 
 export async function mockTwitchApi(): Promise<typeof twitchApiModule> {
-  jest.unstable_mockModule("../src/twitch-api.js", () => {
+  jest.unstable_mockModule("fluid-queue/twitch-api.js", () => {
     class TwitchApi {
       async setup() {
         // do nothing
@@ -363,8 +366,8 @@ export async function mockTwitchApi(): Promise<typeof twitchApiModule> {
       twitchApi: new TwitchApi(),
     };
   });
-  return await import("../src/twitch-api.js");
-  //return jest.requireMock<typeof twitchApiModule>("../src/twitch-api.js");
+  return await import("fluid-queue/twitch-api.js");
+  //return jest.requireMock<typeof twitchApiModule>("fluid-queue/twitch-api.js");
 }
 
 /**
@@ -454,16 +457,16 @@ const simRequireIndex = async (
     fs = (await import("fs")).default;
 
     // import settings
-    settings = (await import("../src/settings.js")).default;
+    settings = (await import("fluid-queue/settings.js")).default;
 
     // import libraries
-    chatbot = await import("../src/chatbot.js");
-    twitch = (await import("../src/twitch.js")).twitch;
-    const queue = await import("../src/queue.js");
+    chatbot = await import("fluid-queue/chatbot.js");
+    twitch = (await import("fluid-queue/twitch.js")).twitch;
+    const queue = await import("fluid-queue/queue.js");
     quesoqueue = queue.quesoqueue();
 
     // run index.js
-    await import("../src/index.js");
+    await import("fluid-queue/index.js");
     if (chatbot === undefined) {
       throw new Error("chatbot was not loaded correctly");
     }

--- a/tests/subs-and-mods.test.ts
+++ b/tests/subs-and-mods.test.ts
@@ -11,13 +11,13 @@ import {
   simSetSubscribers,
   simSetModerators,
 } from "./simulation.js";
-import { Queue, QueueDataMap, OnlineOfflineList } from "../src/queue.js";
+import { Queue, QueueDataMap, OnlineOfflineList } from "fluid-queue/queue.js";
 import {
   EventSubChannelSubscriptionEvent,
   EventSubChannelSubscriptionEndEvent,
   EventSubChannelModeratorEvent,
 } from "@twurple/eventsub-base";
-import { QueueSubmitter } from "../src/extensions-api/queue-entry.js";
+import { QueueSubmitter } from "fluid-queue/extensions-api/queue-entry.js";
 
 // Set up the fake timers
 jest.useFakeTimers();

--- a/tests/twitch.test.ts
+++ b/tests/twitch.test.ts
@@ -6,8 +6,8 @@ import {
   mockTwitchApi,
   createMockVolume,
 } from "./simulation.js";
-import { Settings } from "../src/settings-type.js";
-import { User } from "../src/extensions-api/queue-entry.js";
+import { Settings } from "fluid-queue/settings-type.js";
+import { User } from "fluid-queue/extensions-api/queue-entry.js";
 import * as timers from "timers";
 import { createFsFromVolume } from "memfs";
 
@@ -85,7 +85,7 @@ async function setupMocks() {
   // mocks
   const twitchApi = (await mockTwitchApi()).twitchApi;
 
-  const twitch = (await import("../src/twitch.js")).twitch;
+  const twitch = (await import("fluid-queue/twitch.js")).twitch;
 
   // mock chatters
   asMock(twitchApi, "getChatters").mockImplementation(() =>
@@ -94,7 +94,7 @@ async function setupMocks() {
   jest.unstable_mockModule("../src/settings", () => {
     return { default: {} };
   });
-  const settings = (await import("../src/settings.js")).default;
+  const settings = (await import("fluid-queue/settings.js")).default;
   replace(settings, Settings.parse(defaultTestSettings));
 
   return { settings, twitch, twitchApi };
@@ -275,7 +275,7 @@ test("online users", async () => {
 
 test("createOnlineUsers:empty", async () => {
   await setupMocks();
-  const { createOnlineUsers } = await import("../src/twitch.js");
+  const { createOnlineUsers } = await import("fluid-queue/twitch.js");
   const users: User[] = [];
   const result = createOnlineUsers(users);
   expect(result.users).toEqual(new Map());
@@ -301,7 +301,7 @@ function createUser(i: number): User {
 
 test("createOnlineUsers:users", async () => {
   await setupMocks();
-  const { createOnlineUsers } = await import("../src/twitch.js");
+  const { createOnlineUsers } = await import("fluid-queue/twitch.js");
   const users: User[] = Array.from({ length: 25 }, (_, i) => createUser(i));
   const result = createOnlineUsers(users);
   expect(result.users).toEqual(
@@ -343,7 +343,7 @@ test("createOnlineUsers:users", async () => {
 
 test("createOnlineUsers:users-with-lurkers", async () => {
   await setupMocks();
-  const { createOnlineUsers } = await import("../src/twitch.js");
+  const { createOnlineUsers } = await import("fluid-queue/twitch.js");
   const users: User[] = Array.from({ length: 25 }, (_, i) => createUser(i));
   const lurkers = (user: User) => parseInt(user.id) % 3 == 0;
   const filter = (user: User) => !lurkers(user);
@@ -405,7 +405,7 @@ test("createOnlineUsers:users-with-lurkers", async () => {
 
 test("createOnlineUsers:users-with-lurkers-and-subscribers", async () => {
   await setupMocks();
-  const { createOnlineUsers } = await import("../src/twitch.js");
+  const { createOnlineUsers } = await import("fluid-queue/twitch.js");
   const users: User[] = Array.from({ length: 25 }, (_, i) => createUser(i));
   const lurkers = (user: User) => parseInt(user.id) % 3 == 0;
   const filter0 = (user: User) => !lurkers(user);

--- a/tests/weight.test.ts
+++ b/tests/weight.test.ts
@@ -10,7 +10,7 @@ import {
   EMPTY_CHATTERS,
   DEFAULT_TEST_SETTINGS,
 } from "./simulation.js";
-import { Queue, QueueDataMap, WeightedList } from "../src/queue.js";
+import { Queue, QueueDataMap, WeightedList } from "fluid-queue/queue.js";
 
 // console checks
 const consoleWarnMock = jest.spyOn(global.console, "warn");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,10 @@
     "noEmit": true,
     "allowJs": false,
     "moduleResolution": "node16",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "paths": {
+      "fluid-queue/*": ["./src/*"]
+    }
   },
   "include": ["src/**/*", "tests/**/*", "build.ts", "dist.ts"],
   "exclude": []


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you run `eslint` on the code and resolved any errors?
- [x] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

Inspired by [the @site alias from docusaurus](https://docusaurus.io/docs/next/markdown-features/react#importing-components), this PR introduces the `fluid-queue` alias that will be resolved to the `src` directory.

### Benefits

This makes it easier to include source files when writing tests instead of having to use the correct amount of `../` paths one can just use `fluid-queue` to refer to the source directory in tests.
Note that this resolution also works inside the `src` folder and esbuild will resolve those imports correctly as well, however I would recommend not using `fluid-queue` in import links within the sources.

Also the contents of the `tests/jest.config.json` are now less cursed.

### Potential drawbacks

Someone could use for example `fluid-queue/queue.js` instead of `../queue.js` for example as an import within sources which would be confusing.
I tried to set it up such that only tests could use that alias, but I could not make it working (by creating a second `tsconfig.json` file).

### Open Questions

We could also consider renaming this alias to something like `@src`, but I quite like `fluid-queue` as it is the package name and it looks like you are just importing the files as if `fluid-queue` was installed as a node module.
~~Maybe it could also just point to the root and then the imports would need to be changed to `fluid-queue/src` instead.~~
