### PR TITLE
Enhance settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,11 @@
 - Levels of users who were not online for a while can now be cleared with `!clear {duration}` where duration can be multiple numbers followed by a unit (`min`, `hours`, `months`, etc. for a full list see [the documentation of timestring](https://github.com/mike182uk/timestring/tree/7.0.0#keywords)). For example `!clear 6 months 12 hours` clears all levels from everywhone who was not last online 6 months and 12 hours ago.
 - Console messages printed by the bot are now timestamped, and errors and warnings printed in color with `chalk`.
 
-## New settings
+## Settings
 
+- The settings `level_timeout` and `message_cooldown` are now set using a duration which are multiple numbers followed by a unit (`min`, `hours`, `months`, etc. for a full list see [the documentation of timestring](https://github.com/mike182uk/timestring/tree/7.0.0#keywords)) or alternatively an [ISO-8601 duration format](https://js-joda.github.io/js-joda/class/packages/core/src/Duration.js~Duration.html#static-method-parse).
+  For example: `10 seconds`, `3 minutes`, and `10 minutes 30 seconds` etc.  
+  To convert the values `level_timeout` and `message_cooldown` to the new duration format add `minutes` to the number of `level_timeout` and `seconds` to the number of `message_cooldown`.
 - There is a new setting `clear` which can be set to the default argument of `!clear`. For example setting `clear` to `"all"` will make it so `!clear` will call `!clear all` or setting it to `6 months` would call `!clear 6 months` by default. Setting this to `null` (or not setting the value) will result into a usage message of the `!clear` command when using `!clear`.
 
 ## Bug fixes

--- a/settings/settings.example.yml
+++ b/settings/settings.example.yml
@@ -9,8 +9,8 @@ custom_codes_enabled: false # is the toggle for whether or not custom codes are 
 romhacks_enabled: false # if the "customlevel" resolver is enabled, one can add ROMhacks using `!add ROMhack`.
 uncleared_enabled: false # if the "customlevel" resolver is enabled, one can add uncleared levels using `!add Uncleared`.
 max_size: 100 # is the maximum amount of levels allowed in the queue at once.
-level_timeout: null # is the amount of time in minutes a level can be played before the bot will inform you that time is up. The default value of `null` means that the timer is deactivated.
-message_cooldown: 10 # is the amount of time in seconds that a user must wait before !list will display the levels in the queue after a previous use.
+level_timeout: null # is the amount of time a level can be played before the bot will inform you that time is up. The default value of `null` means that the timer is deactivated. Example values: `10` (minutes), `10 minutes 30 seconds`, `1 hour`. Supplying no unit is deprecated and might stop in a future version, but it will imply a value of minutes for now.
+message_cooldown: 10 seconds # is the amount of time that a user must wait before !list will display the levels in the queue after a previous use. Example values: `10 seconds`, `1 minute`, `1 second`, `100 milliseconds`. Supplying no unit is deprecated and might stop in a future version, but it will imply a value of seconds for now.
 subscriberWeightMultiplier: 1.0 # is the number added as a wait time for subscribers. Setting this to 1.2 for example will give subscribers an advantage for weighted random, because they would get 6 minutes of wait time per 5 minutes of waiting. This can be set to anything greater than or equal to 1.0.
 
 # will be selected in upon using `!level`

--- a/src/extensions-api/resolvers.ts
+++ b/src/extensions-api/resolvers.ts
@@ -8,6 +8,7 @@ import {
   QueueSubmitter,
 } from "./queue-entry.js";
 import { log } from "../chalk-print.js";
+import { ZodTypeUnknown } from "../zod.js";
 
 const defaultActivated: string[] = [
   "smm2",
@@ -99,7 +100,7 @@ export interface UsingDataStage<
     deserializer: Deserialize<Data>,
     serializer?: Serialize<Data>
   ): QueueEntryApi<AdjustStages<S, T & { data: Data }, [...A, Data]>>;
-  usingData<Schema extends z.ZodTypeAny>(
+  usingData<Schema extends ZodTypeUnknown>(
     schema: Schema,
     serializer?: Serialize<z.input<Schema>>
   ): QueueEntryApi<

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ if (settings.level_timeout) {
     chatbot_helper.say(
       i18next.t("timerExpired", { channel: settings.channel })
     );
-  }, settings.level_timeout * 1000 * 60);
+  }, settings.level_timeout);
 }
 
 function get_remainder(x: string) {
@@ -690,7 +690,7 @@ async function HandleMessage(
     } else if (settings.message_cooldown) {
       if (can_list) {
         can_list = false;
-        setTimeout(() => (can_list = true), settings.message_cooldown * 1000);
+        setTimeout(() => (can_list = true), settings.message_cooldown);
         do_list = true;
       } else {
         respond(i18next.t("scrollUp"));

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { twitchApi } from "./twitch-api.js";
 import { User } from "./extensions-api/queue-entry.js";
 import { log, warn, error } from "./chalk-print.js";
+import { ZodTypeUnknown } from "./zod.js";
 
 const DATA_DIRECTORY = "data";
 const VERSIONED_FILE_NAME = path.join(DATA_DIRECTORY, "queue.json");
@@ -104,7 +105,9 @@ interface ExtensionDataV2<T> {
   data: T;
 }
 
-function ExtensionDataV2<ItemType extends z.ZodTypeAny>(itemSchema: ItemType) {
+function ExtensionDataV2<ItemType extends ZodTypeUnknown>(
+  itemSchema: ItemType
+) {
   return z.object({
     version: z
       .string()
@@ -192,7 +195,9 @@ type SubmittedEntryV3 = z.infer<typeof SubmittedEntryV3>;
 
 type ExtensionDataV3<T> = ExtensionDataV2<T>;
 
-function ExtensionDataV3<ItemType extends z.ZodTypeAny>(itemSchema: ItemType) {
+function ExtensionDataV3<ItemType extends ZodTypeUnknown>(
+  itemSchema: ItemType
+) {
   return ExtensionDataV2(itemSchema);
 }
 

--- a/src/settings-type.ts
+++ b/src/settings-type.ts
@@ -23,17 +23,19 @@ const list_options: readonly [string, ...string[]] = [
   "none",
 ];
 
-function deprecatedValue<V, N>(value: V, newValue: N, ctx: RefinementCtx) {
+export function deprecatedValue<V, N>(
+  value: V,
+  newValue: N,
+  ctx: RefinementCtx
+) {
   warn(
-    `Setting ${String(
-      value
-    )} for ${ctx.path.toString()} is deprected, please replace the value with "${String(
-      newValue
-    )}".`
+    `Setting ${String(value)} for ${ctx.path.join(
+      "."
+    )} is deprected, please replace the value with ${String(newValue)}.`
   );
 }
 
-const TimeValue = z.string().transform((value) => {
+export const TimeValue = z.string().transform((value) => {
   value = value.trim();
   if (value.startsWith("P")) {
     // ISO-8601
@@ -49,7 +51,7 @@ const DeprectedMinutesValue = z
   .safe()
   .transform((value, ctx) => {
     // do not translate this newValue as configuration is only done in english
-    const newValue = `${value} minute${value == 1 ? "" : "s"}`;
+    const newValue = JSON.stringify(`${value} minute${value == 1 ? "" : "s"}`);
     deprecatedValue(value, newValue, ctx);
     return value * 1000 * 60;
   })
@@ -59,7 +61,7 @@ const DeprectedSecondsValue = z
   .safe()
   .transform((value, ctx) => {
     // do not translate this newValue as configuration is only done in english
-    const newValue = `${value} second${value == 1 ? "" : "s"}`;
+    const newValue = JSON.stringify(`${value} second${value == 1 ? "" : "s"}`);
     deprecatedValue(value, newValue, ctx);
     return value * 1000;
   })
@@ -205,7 +207,7 @@ export const Settings = z
       .nullable()
       .default(null),
     extensionOptions: z
-      .record(z.string(), z.record(z.string(), z.coerce.string()))
+      .record(z.string(), z.unknown())
       .describe("any options for your enabled resolvers")
       .nullable()
       .default(null),

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,0 +1,6 @@
+import { ZodType } from "zod";
+
+/**
+ * This type is used instead of z.ZodTypeAny
+ */
+export type ZodTypeUnknown = ZodType<unknown>;

--- a/tests/chat-logs/chat/add.test.log
+++ b/tests/chat-logs/chat/add.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","offline_message":true,"max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","offline_message":true,"max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log
@@ -40,7 +40,7 @@ chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 [02:23:35] @^FurretWalkBot: !add invalid level code
 [02:23:36] @^helperblock: FurretWalkBot, that is an invalid level code.
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","offline_message":true,"max_size":1,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","offline_message":true,"max_size":1,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 
 [02:24:35] ~%?liquidnya: !add NB0-1MD-SLG
 [02:24:35] @^helperblock: liquidnya, NB0-1MD-SLG has been added to the queue.

--- a/tests/chat-logs/chat/broadcaster-only.test.log
+++ b/tests/chat-logs/chat/broadcaster-only.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":["next", "random"],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":["next", "random"],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/clear.test.log
+++ b/tests/chat-logs/chat/clear.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/current-level-persists.test.log
+++ b/tests/chat-logs/chat/current-level-persists.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/custom-codes.test.log
+++ b/tests/chat-logs/chat/custom-codes.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"custom_codes_enabled":true,"showMakerCode":false}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","custom_codes_enabled":true,"showMakerCode":false}
 # restart to test with custom_codes_enabled set to true from the very beginning
 restart
 # chatters 

--- a/tests/chat-logs/chat/custom-levels.test.log
+++ b/tests/chat-logs/chat/custom-levels.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"custom_codes_enabled":true,"showMakerCode":false}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","custom_codes_enabled":true,"showMakerCode":false}
 # restart to test with custom_codes_enabled set to true from the very beginning
 restart
 # chatters

--- a/tests/chat-logs/chat/dismiss.test.log
+++ b/tests/chat-logs/chat/dismiss.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":["next", "random"],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":["next", "random"],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/ellipses.test.log
+++ b/tests/chat-logs/chat/ellipses.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/filesystem-fault.test.log
+++ b/tests/chat-logs/chat/filesystem-fault.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/frozen-time.test.log
+++ b/tests/chat-logs/chat/frozen-time.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/invalid-level-code.test.log
+++ b/tests/chat-logs/chat/invalid-level-code.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 # chatters 
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/level-order-restart.test.log
+++ b/tests/chat-logs/chat/level-order-restart.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":["next", "random"],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":["next", "random"],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 # chatters 
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/maker-code.test.log
+++ b/tests/chat-logs/chat/maker-code.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":true,"clear":"all"}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log
@@ -40,7 +40,7 @@ chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 [02:23:35] @^FurretWalkBot: !add invalid level code
 [02:23:36] @^helperblock: FurretWalkBot, that is an invalid level code.
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":1,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":1,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":true,"clear":"all"}
 
 [02:24:35] ~%?liquidnya: !add NB0-1MD-SLG
 [02:24:35] @^helperblock: liquidnya, NB0-1MD-SLG (maker code) has been added to the queue.

--- a/tests/chat-logs/chat/ocw.test.log
+++ b/tests/chat-logs/chat/ocw.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false}
 # chatters 
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log
@@ -23,7 +23,7 @@ chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 [20:29:54] @^helperblock: liquidnya, that is an invalid level code.
 
 # configure ocw
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "true"}}}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "true"}}}
 # restart to reload settings
 restart
 
@@ -40,7 +40,7 @@ restart
 [20:36:21] @^helperblock: liquidnya, RHCD08CC8 (OCW) has been added to the queue.
 
 # showMakerCode
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "true"}}}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "true"}}}
 # restart to reload settings
 restart
 
@@ -50,7 +50,7 @@ restart
 [20:32:21] @^helperblock: liquidnya, RHCD08CC8 (OCW maker code) has been added to the queue.
 
 # removeDashes off
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "false"}}}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "false"}}}
 # restart to reload settings
 restart
 

--- a/tests/chat-logs/chat/ocw.test.log
+++ b/tests/chat-logs/chat/ocw.test.log
@@ -23,7 +23,7 @@ chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 [20:29:54] @^helperblock: liquidnya, that is an invalid level code.
 
 # configure ocw
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "true"}}}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes":true}}}
 # restart to reload settings
 restart
 
@@ -40,7 +40,7 @@ restart
 [20:36:21] @^helperblock: liquidnya, RHCD08CC8 (OCW) has been added to the queue.
 
 # showMakerCode
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "true"}}}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes":true}}}
 # restart to reload settings
 restart
 
@@ -50,7 +50,7 @@ restart
 [20:32:21] @^helperblock: liquidnya, RHCD08CC8 (OCW maker code) has been added to the queue.
 
 # removeDashes off
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes": "false"}}}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":true,"resolvers":["smm2","ocw","smm2-lenient","ocw-lenient"],"extensionOptions":{"ocw":{"removeDashes":false}}}
 # restart to reload settings
 restart
 

--- a/tests/chat-logs/chat/odds.test.log
+++ b/tests/chat-logs/chat/odds.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/open-close-clear.test.log
+++ b/tests/chat-logs/chat/open-close-clear.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/persistence.test.log
+++ b/tests/chat-logs/chat/persistence.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5, "start_open": true,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds", "start_open": true,"showMakerCode":false,"clear":"all"}
 # restart to start queue open (reload settings)
 restart
 # chatters

--- a/tests/chat-logs/chat/random.test.log
+++ b/tests/chat-logs/chat/random.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false}
 # chatters 
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/remove.test.log
+++ b/tests/chat-logs/chat/remove.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false}
 # chatters 
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/username-argument-dip.test.log
+++ b/tests/chat-logs/chat/username-argument-dip.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/username-argument-remove.test.log
+++ b/tests/chat-logs/chat/username-argument-remove.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/wait-msec.test.log
+++ b/tests/chat-logs/chat/wait-msec.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5, "start_open": true,"showMakerCode":false}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds", "start_open": true,"showMakerCode":false}
 # restart to start queue open (reload settings)
 restart
 # chatters 

--- a/tests/chat-logs/chat/wait-multiplier.test.log
+++ b/tests/chat-logs/chat/wait-multiplier.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5, "start_open": true, "subscriberWeightMultiplier": 1.2,"showMakerCode":false}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds", "start_open": true, "subscriberWeightMultiplier": 1.2,"showMakerCode":false}
 # restart to start queue open (reload settings)
 restart
 # chatters 

--- a/tests/chat-logs/chat/weight-crash.test.log
+++ b/tests/chat-logs/chat/weight-crash.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"clear":"all"}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log

--- a/tests/chat-logs/chat/weight-remove.test.log
+++ b/tests/chat-logs/chat/weight-remove.test.log
@@ -1,7 +1,7 @@
 # this captures the chat messages of that user as the chatbot responses
 chatbot helperblock
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"list": "weight","message_cooldown":5,"showMakerCode":false,"enable_absolute_position":true,"clear":"all"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"list": "weight","message_cooldown":"5 seconds","showMakerCode":false,"enable_absolute_position":true,"clear":"all"}
 # chatters
 chatters ~%?liquidnya, @^FurretWalkBot, @''?^StreamElements, ^ViewerLevels
 # chatty chat log
@@ -37,7 +37,7 @@ queue.json/entries/queue [{"code":"NB0-1MD-SLG","type":"smm2","submitter":{"id":
 [16:26:48] @^FurretWalkBot: !list
 [16:26:48] @^helperblock: 2 online: (no current level), liquidnya (99.9%), FurretWalkBot (0.0693%) (0 offline)
 
-settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"showMakerCode":false,"enable_absolute_position":true,"position":"both"}
+settings {"channel":"liquidnya","clientId":"","clientSecret":"","max_size":50,"level_timeout":"10 minutes","level_selection":[],"message_cooldown":"5 seconds","showMakerCode":false,"enable_absolute_position":true,"position":"both"}
 restart
 
 [16:26:48] @^FurretWalkBot: !pos

--- a/tests/simulation.ts
+++ b/tests/simulation.ts
@@ -31,7 +31,7 @@ const DEFAULT_TEST_SETTINGS = {
   clientId: "",
   clientSecret: "",
   max_size: 50,
-  level_timeout: 10,
+  level_timeout: "10 minutes",
   level_selection: [
     "next",
     "subnext",
@@ -40,7 +40,7 @@ const DEFAULT_TEST_SETTINGS = {
     "subrandom",
     "modrandom",
   ],
-  message_cooldown: 5,
+  message_cooldown: "5 seconds",
 };
 // constants
 const EMPTY_CHATTERS: User[] = [];


### PR DESCRIPTION
### Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you run `eslint` on the code and resolved any errors?
- [x] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

This PR introduces:

- A duration format for settings that are portraying a time duration.
- `extensionOptions` to be of any type.

For example:

Instead of configuring `message_cooldown: 10`, one has to configure `message_cooldown: 10 seconds` and instead of configuring something like `level_timeout: 15`, one has to configure `level_timeout: 15 minutes`.
The format is either [timestring](https://github.com/mike182uk/timestring/tree/7.0.0#keywords) or alternatively an [ISO-8601 duration format](https://js-joda.github.io/js-joda/class/packages/core/src/Duration.js~Duration.html#static-method-parse).
Note that values like `10`, and `15` are still allowed, just deprecated.
`extensionOptions.ocw.removeDashes` is now a `boolean`, but strings can still work, but are deprecated.

### Benefits

Using units will make it more clear what time is configured and converting between different time units is not needed by the user.
Using any types for the values of `extensionOptions` has the benefit of allowing lists or more complex types instead of just strings and also has the benefit of using type checking more easily by using zod.

### Potential drawbacks

Values of settings have changed and the user has to correct the values, because in a future version the old values might not be accepted any more.

### Further questions

While we are at it, maybe we should rename settings from `snake_case` to `camelCase`?
For example introduce the setting `levelSelection` that has a fallback value for `level_selection` (deprecated).
