### PR TITLE
Auto Timer feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [Unreleased]
+
+## New features
+
+- Added an option (default off) to automatically start the level timer when pulling a level (#140).
+
 # v2.0.0-rc.1
 
 ## Breaking changes

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A queue system for Super Mario Maker 2 levels.
 
 This project is based on Queso Queue Plus, which was originally developed by Shoujo (<https://github.com/ToransuShoujo/quesoqueue_plus/>) and diceguyd30 (<https://github.com/diceguyd30/queso_to_go_template>).
 
-To get started with the bot, check out the [setup instructions](https://fluid-queue.dev/setup) on our site. If you have any issues, let us know by [opening an issue](https://github.com/fluid-queue/fluid-queue/issues/new) on Github or joining our [Discord server](https://discord.gg/GCM98NKHbF)!
+To get started with the bot, check out the [setup instructions](https://fluid-queue.dev/docs) on our site. If you have any issues, let us know by [opening an issue](https://github.com/fluid-queue/fluid-queue/issues/new) on Github or joining our [Discord server](https://discord.gg/GCM98NKHbF)!
 
 ## Docker Tags
 

--- a/settings/settings.example.yml
+++ b/settings/settings.example.yml
@@ -11,6 +11,7 @@ romhacks_enabled: false # if the "customlevel" resolver is enabled, one can add 
 uncleared_enabled: false # if the "customlevel" resolver is enabled, one can add uncleared levels using `!add Uncleared`.
 max_size: 100 # is the maximum amount of levels allowed in the queue at once.
 level_timeout: null # is the amount of time a level can be played before the bot will inform you that time is up. The default value of `null` means that the timer is deactivated. Example values: `10` (minutes), `10 minutes 30 seconds`, `1 hour`. Supplying no unit is deprecated and might stop in a future version, but it will imply a value of minutes for now.
+auto_timer: false # is whether or not to automatically start the timer upon pulling a level (e.g. with `!level`)
 message_cooldown: 10 seconds # is the amount of time that a user must wait before !list will display the levels in the queue after a previous use. Example values: `10 seconds`, `1 minute`, `1 second`, `100 milliseconds`. Supplying no unit is deprecated and might stop in a future version, but it will imply a value of seconds for now.
 subscriberWeightMultiplier: 1.0 # is the number added as a wait time for subscribers. Setting this to 1.2 for example will give subscribers an advantage for weighted random, because they would get 6 minutes of wait time per 5 minutes of waiting. This can be set to anything greater than or equal to 1.0.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -619,7 +619,10 @@ async function HandleMessage(
     }
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!next_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
     if (
       selection_mode != "weightedrandom" &&
@@ -635,55 +638,70 @@ async function HandleMessage(
       channelPointManager.removeFromSkipQueue(next_level.submitter);
     }
   } else if (aliases.isAlias("next", message) && sender.isBroadcaster) {
+    const next_level = await quesoqueue.next();
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!next_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
-    const next_level = await quesoqueue.next();
     respond(next_level_message(next_level));
     // Commands other than !level do not check the skip queue, points should be refunded if a level is pulled
     if (next_level) {
       channelPointManager.removeFromSkipQueue(next_level.submitter);
     }
   } else if (aliases.isAlias("subnext", message) && sender.isBroadcaster) {
+    const next_level = await quesoqueue.subnext();
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!next_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
-    const next_level = await quesoqueue.subnext();
     respond(next_level_message(next_level));
     // Commands other than !level do not check the skip queue, points should be refunded if a level is pulled
     if (next_level) {
       channelPointManager.removeFromSkipQueue(next_level.submitter);
     }
   } else if (aliases.isAlias("modnext", message) && sender.isBroadcaster) {
+    const next_level = await quesoqueue.modnext();
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!next_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
-    const next_level = await quesoqueue.modnext();
     respond(next_level_message(next_level));
     // Commands other than !level do not check the skip queue, points should be refunded if a level is pulled
     if (next_level) {
       channelPointManager.removeFromSkipQueue(next_level.submitter);
     }
   } else if (aliases.isAlias("random", message) && sender.isBroadcaster) {
+    const next_level = await quesoqueue.random();
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!next_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
-    const next_level = await quesoqueue.random();
     respond(next_level_message(next_level));
     // Commands other than !level do not check the skip queue, points should be refunded if a level is pulled
     if (next_level) {
       channelPointManager.removeFromSkipQueue(next_level.submitter);
     }
   } else if (aliases.isAlias("weightednext", message) && sender.isBroadcaster) {
+    const next_level = await quesoqueue.weightednext();
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!next_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
-    const next_level = await quesoqueue.weightednext();
     respond(weightednext_level_message(next_level));
     // Commands other than !level do not check the skip queue, points should be refunded if a level is pulled
     if (next_level) {
@@ -693,11 +711,14 @@ async function HandleMessage(
     aliases.isAlias("weightedrandom", message) &&
     sender.isBroadcaster
   ) {
+    const next_level = await quesoqueue.weightedrandom();
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!next_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
-    const next_level = await quesoqueue.weightedrandom();
     respond(weightedrandom_level_message(next_level));
     // Commands other than !level do not check the skip queue, points should be refunded if a level is pulled
     if (next_level) {
@@ -707,11 +728,14 @@ async function HandleMessage(
     aliases.isAlias("weightedsubnext", message) &&
     sender.isBroadcaster
   ) {
+    const next_level = await quesoqueue.weightedsubnext();
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!next_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
-    const next_level = await quesoqueue.weightedsubnext();
     respond(weightednext_level_message(next_level, " (subscriber)"));
     // Commands other than !level do not check the skip queue, points should be refunded if a level is pulled
     if (next_level) {
@@ -721,33 +745,42 @@ async function HandleMessage(
     aliases.isAlias("weightedsubrandom", message) &&
     sender.isBroadcaster
   ) {
+    const next_level = await quesoqueue.weightedsubrandom();
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!next_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
-    const next_level = await quesoqueue.weightedsubrandom();
     respond(weightedrandom_level_message(next_level, " (subscriber)"));
     // Commands other than !level do not check the skip queue, points should be refunded if a level is pulled
     if (next_level) {
       channelPointManager.removeFromSkipQueue(next_level.submitter);
     }
   } else if (aliases.isAlias("subrandom", message) && sender.isBroadcaster) {
+    const next_level = await quesoqueue.subrandom();
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!next_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
-    const next_level = await quesoqueue.subrandom();
     respond(next_level_message(next_level));
     // Commands other than !level do not check the skip queue, points should be refunded if a level is pulled
     if (next_level) {
       channelPointManager.removeFromSkipQueue(next_level.submitter);
     }
   } else if (aliases.isAlias("modrandom", message) && sender.isBroadcaster) {
+    const next_level = await quesoqueue.modrandom();
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!next_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
-    const next_level = await quesoqueue.modrandom();
     respond(next_level_message(next_level));
     // Commands other than !level do not check the skip queue, points should be refunded if a level is pulled
     if (next_level) {
@@ -756,22 +789,27 @@ async function HandleMessage(
   } else if (aliases.isAlias("punt", message) && sender.isBroadcaster) {
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
+      // Always pause the timer
       level_timer.pause();
     }
     respond(await quesoqueue.punt());
   } else if (aliases.isAlias("dismiss", message) && sender.isBroadcaster) {
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
+      // Always pause the timer
       level_timer.pause();
     }
     respond(await quesoqueue.dismiss());
   } else if (aliases.isAlias("select", message) && sender.isBroadcaster) {
     const username = get_remainder(message);
+    const dip_level = quesoqueue.dip(username);
     if (settings.level_timeout && level_timer != null) {
       level_timer.restart();
-      level_timer.pause();
+      // Pause the timer if there's no next level, or the auto timer isn't set
+      if (!dip_level || !settings.auto_timer) {
+        level_timer.pause();
+      }
     }
-    const dip_level = quesoqueue.dip(username);
     if (dip_level !== undefined) {
       twitch.notLurkingAnymore(dip_level.submitter);
       respond(i18next.t("nowPlayingBasic", { level: dip_level }));

--- a/src/settings-type.ts
+++ b/src/settings-type.ts
@@ -134,6 +134,10 @@ export const Settings = z
     )
       .nullable()
       .default(null),
+    auto_timer: z
+      .boolean()
+      .describe("whether to start the timer automatically when picking a level")
+      .default(false),
     level_selection: z
       .enum(order_options)
       .array()


### PR DESCRIPTION
### Checklist

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you run `npm run check` on the code and resolved any errors?
- [X] Have you run `npm test` and all tests are passing?
- [ ] Have you added new tests for any new functions created? -- **N/A pending reworked tests**
- [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you updated CHANGELOG.md to add your changed under the `[Unreleased]` heading?

### Description

Implements an option to automatically start the timer when a level is pulled, per #139.

Will update the docs in fluid-queue/fluid-docs to better describe both the timer and this feature once this is merged.

### Benefits

This adds requested functionality to the bot.

### Potential drawbacks

There should be no drawbacks here, as this adds new optional functionality.